### PR TITLE
[impl] #11 Makefile: layered targets + install/uninstall postconditions + publish-quality

### DIFF
--- a/CEREMONIES.md
+++ b/CEREMONIES.md
@@ -45,7 +45,7 @@ After the final deliverable:
 6. **Test coverage review** (tasks that change code): consult the devlog `### 3.5 Test coverage review` subsection. For each code change or refactoring made during the task, decide one of: (a) covered by an existing test — note which, (b) add a new test — the test must also exercise the pre-change code so it would have caught the original failure mode, (c) justify absence — test not worth writing here (e.g. pure prose change, one-off script). Record the decisions in § 3.5.
    This is distinct from step 5 (Test update): step 5 ports _verification commands_ the task produced into the suite; step 6 asks the reverse question — did the task's _own changes_ warrant coverage?
 7. **Gate check**: before proceeding to retrospective, explicitly verify all closure gates — acceptance criteria met, all deliverables committed, user approvals for critical items obtained. If any gate fails, resolve before continuing.
-   - Implementation tasks: `make test-full` must pass
+   - Implementation tasks: `make test` must pass
 8. Task retrospective: draft as a voting table for user review [charter § 12.6]:
 
    | #   | Point             | Agent | User     |

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,15 @@
 #    - Low-level  targets: no other-target deps; recipe does ONE thing.
 #    - High-level targets: compose low-levels only; NO high→high (neither
 #      via `target: deps` lines nor via `$(MAKE) X` submakes in recipes).
+#      MARK each high-level target with a `# Purpose: <low-level list>`
+#      comment immediately above its `.PHONY:` line. This comment is the
+#      FORMAL marker that distinguishes high-level from low-level — there
+#      is no naming convention that does the same job. Continuation lines
+#      start with `#` + leading whitespace (no new `Purpose:` keyword).
 #    High-level targets live with their purpose group; no dedicated section.
 #    Audit: scan every `target: …` line and every `$(MAKE) …` in recipes;
-#    each referent must be a low-level target.
+#    each referent must be a low-level target. The Purpose comment lists
+#    the same set, in execution order.
 #
 # 2. Help docstrings — ≤60 CHARS (so `make help` lines fit 80 columns):
 #    Format: `target: ## doc string here`. `make help` prints
@@ -80,6 +86,7 @@ format: ## ruff format + lint autofix (modifies code)
 	uv run ruff format src
 	uv run ruff check --fix src
 
+# Purpose: lint test-unit test-smoke
 .PHONY: check
 check: lint test-unit test-smoke ## lint + unit + smoke (CI / pre-PR)
 
@@ -101,9 +108,11 @@ test-e2e: ## run e2e tests (slow; drives real Claude Code)
 	uv sync --extra dev --extra e2e
 	uv run pytest tests/e2e
 
+# Purpose: test-unit test-smoke
 .PHONY: test-full
 test-full: test-unit test-smoke ## unit + smoke (fast default)
 
+# Purpose: test-unit test-smoke
 .PHONY: test
 test: test-unit test-smoke ## alias for test-full
 
@@ -123,7 +132,7 @@ uninstall: ## uninstall from user account (1)
 	uv tool uninstall claude-busy-monitor
 
 .PHONY: verify-installed
-verify-installed: ## assert $(CLI) present and --version matches CHANGES.md
+verify-installed: ## assert command present and --version matches CHANGES.md
 	@if [ ! -x "$(CLI)" ]; then \
 		echo "verify-installed: missing $(CLI) (run 'make install' first)" >&2; exit 1; \
 	fi; \
@@ -138,7 +147,7 @@ verify-installed: ## assert $(CLI) present and --version matches CHANGES.md
 	echo "verify-installed: OK ($(CLI) v$$ACTUAL)"
 
 .PHONY: verify-uninstalled
-verify-uninstalled: ## assert $(CLI) absent
+verify-uninstalled: ## assert command absent
 	@if [ -e "$(CLI)" ]; then \
 		echo "verify-uninstalled: $(CLI) still present (run 'make uninstall' first)" >&2; exit 1; \
 	fi; \
@@ -152,6 +161,8 @@ install-legacy: ## install lib user-wide (1) (2)
 uninstall-legacy: ## uninstall lib user-wide (1) (2)
 	pip uninstall -y claude-busy-monitor || pip uninstall -y --break-system-packages claude-busy-monitor
 
+# Purpose: uninstall verify-uninstalled clean lint test-unit test-smoke
+#          install verify-installed
 .PHONY: cycle
 cycle: ## uninstall + verify, clean, tests, install + verify (1)
 	@echo "About to uninstall claude-busy-monitor and rebuild from scratch."
@@ -169,6 +180,8 @@ cycle: ## uninstall + verify, clean, tests, install + verify (1)
 ################################################################################
 ## Publish:: ##
 
+# Purpose: lint test-unit test-smoke build uninstall verify-uninstalled
+#          clean install verify-installed
 .PHONY: publish-quality
 publish-quality: ## pre-publish gate: lint + tests + cycle; no upload (1)
 	@echo "About to run lint + tests + uninstall/install cycle. Does NOT upload."

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # Target layering (#11): two levels.
 #   Low-level   — no other-target deps, recipe does one thing.
 #   High-level  — composes low-levels only (no high→high).
-# High-level targets are grouped at the bottom of this file.
+# High-level targets live with their purpose group, not in a dedicated section.
 
 SHELL := /bin/bash
 VENV  ?= .venv
@@ -67,6 +67,9 @@ format: ## ruff format + lint autofix (modifies code)
 	uv run ruff format src
 	uv run ruff check --fix src
 
+.PHONY: check
+check: lint test-unit test-smoke ## lint + unit + smoke (CI / pre-PR)
+
 ################################################################################
 ## Tests:: ##
 
@@ -76,14 +79,20 @@ test-unit: ## run unit tests (fast, no I/O)
 	uv run pytest tests/unit
 
 .PHONY: test-smoke
-test-smoke: ## run smoke tests (subprocess invocations, no real Claude)
+test-smoke: ## run smoke tests (subprocess; no real Claude)
 	uv sync --extra dev
 	uv run pytest tests/smoke
 
 .PHONY: test-e2e
-test-e2e: ## run e2e tests (slow — drives real Claude Code)
+test-e2e: ## run e2e tests (slow; drives real Claude Code)
 	uv sync --extra dev --extra e2e
 	uv run pytest tests/e2e
+
+.PHONY: test-full
+test-full: test-unit test-smoke ## unit + smoke (fast default)
+
+.PHONY: test
+test: test-unit test-smoke ## alias for test-full
 
 ################################################################################
 ## Build and install:: ##
@@ -93,11 +102,11 @@ build: ## build wheel + sdist into dist/
 	uv build
 
 .PHONY: install
-install: ## install in the user's account (CLI on ~/.local/bin/)
+install: ## install in user account (CLI on ~/.local/bin/) (1)
 	uv tool install --reinstall .
 
 .PHONY: uninstall
-uninstall: ## uninstall from the user's account
+uninstall: ## uninstall from user account (1)
 	uv tool uninstall claude-busy-monitor
 
 .PHONY: verify-installed
@@ -123,39 +132,15 @@ verify-uninstalled: ## assert $(CLI) absent
 	echo "verify-uninstalled: OK ($(CLI) absent)"
 
 .PHONY: install-legacy
-install-legacy: ## install lib user-wide (2)
+install-legacy: ## install lib user-wide (1) (2)
 	uv pip install --user . || pip install --user --break-system-packages .
 
 .PHONY: uninstall-legacy
-uninstall-legacy: ## uninstall lib user-wide (2)
+uninstall-legacy: ## uninstall lib user-wide (1) (2)
 	pip uninstall -y claude-busy-monitor || pip uninstall -y --break-system-packages claude-busy-monitor
 
-.PHONY: publish
-publish: ## upload wheel + sdist to PyPI (user-only; raw — use publish-quality first)
-	uv publish
-
-################################################################################
-## Cleanup:: ##
-
-.PHONY: clean
-clean: ## remove venv, build artefacts, caches
-	rm -rf $(VENV) dist build *.egg-info .ruff_cache .pytest_cache
-	find . -type d -name __pycache__ -prune -exec rm -rf {} +
-
-################################################################################
-## High-level compositions:: ##
-
-.PHONY: test-full
-test-full: test-unit test-smoke ## unit + smoke (fast default)
-
-.PHONY: test
-test: test-unit test-smoke ## alias for test-full (same dep set; not nested)
-
-.PHONY: check
-check: lint test-unit test-smoke ## lint + unit + smoke (CI / pre-PR convenience)
-
 .PHONY: cycle
-cycle: ## full cycle: uninstall → verify → clean → lint+tests → install → verify (1)
+cycle: ## uninstall + verify, clean, tests, install + verify (1)
 	@echo "About to uninstall claude-busy-monitor and rebuild from scratch."
 	@echo "Ctrl-C within 2 seconds to abort."
 	@sleep 2
@@ -168,8 +153,11 @@ cycle: ## full cycle: uninstall → verify → clean → lint+tests → install 
 	$(MAKE) install
 	$(MAKE) verify-installed
 
+################################################################################
+## Publish:: ##
+
 .PHONY: publish-quality
-publish-quality: ## max-quality gate before 'make publish' — verifies, does NOT upload (1)
+publish-quality: ## pre-publish gate: lint + tests + cycle; no upload (1)
 	@echo "About to run lint + tests + uninstall/install cycle. Does NOT upload."
 	@echo "Ctrl-C within 2 seconds to abort."
 	@sleep 2
@@ -183,6 +171,18 @@ publish-quality: ## max-quality gate before 'make publish' — verifies, does NO
 	$(MAKE) install
 	$(MAKE) verify-installed
 	@echo "publish-quality: all gates green. Run 'make publish' to upload."
+
+.PHONY: publish
+publish: ## upload to PyPI (raw; use publish-quality first)
+	uv publish
+
+################################################################################
+## Cleanup:: ##
+
+.PHONY: clean
+clean: ## remove venv, build artefacts, caches
+	rm -rf $(VENV) dist build *.egg-info .ruff_cache .pytest_cache
+	find . -type d -name __pycache__ -prune -exec rm -rf {} +
 
 
 ################################################################################

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,12 @@
 #    Each target's doc follows `##` on its target line.
 #    `make help` prints `  <target><pad-to-col-20><doc>`, room = 60 cols.
 #    Verify after edits: `make help | awk '{print length}' | sort -nr | head`.
+#
+# 3. Order targets within a section by LOGICAL CALL SEQUENCE — the order a
+#    user would naturally invoke them (e.g. install before verify-installed;
+#    uninstall before verify-uninstalled). High-level targets typically come
+#    last (they call the low-levels above), unless a high-level is the
+#    recommended entry (e.g. publish-quality before publish in Publish::).
 # ============================================================================
 
 SHELL := /bin/bash
@@ -124,10 +130,6 @@ build: ## build wheel + sdist into dist/
 install: ## install in user account (CLI on ~/.local/bin/) (1)
 	uv tool install --reinstall .
 
-.PHONY: uninstall
-uninstall: ## uninstall from user account (1)
-	uv tool uninstall claude-busy-monitor
-
 .PHONY: verify-installed
 verify-installed: ## assert command present and --version matches CHANGES.md
 	@if [ ! -x "$(CLI)" ]; then \
@@ -142,6 +144,10 @@ verify-installed: ## assert command present and --version matches CHANGES.md
 		echo "verify-installed: version mismatch (expected $$EXPECTED, got '$$ACTUAL')" >&2; exit 1; \
 	fi; \
 	echo "verify-installed: OK ($(CLI) v$$ACTUAL)"
+
+.PHONY: uninstall
+uninstall: ## uninstall from user account (1)
+	uv tool uninstall claude-busy-monitor
 
 .PHONY: verify-uninstalled
 verify-uninstalled: ## assert command absent
@@ -159,7 +165,7 @@ uninstall-legacy: ## uninstall lib user-wide (1) (2)
 	pip uninstall -y claude-busy-monitor || pip uninstall -y --break-system-packages claude-busy-monitor
 
 .PHONY: cycle
-cycle: ## from scratch: uninstall clean tests install verify (1)
+cycle: ## from scratch: uninstall clean lint tests install verify (1)
 	@echo "About to uninstall claude-busy-monitor and rebuild from scratch."
 	@echo "Ctrl-C within 2 seconds to abort."
 	@sleep 2
@@ -176,7 +182,7 @@ cycle: ## from scratch: uninstall clean tests install verify (1)
 ## Publish:: ##
 
 .PHONY: publish-quality
-publish-quality: ## pre-publish gate: lint tests build cycle; no upload (1)
+publish-quality: ## pre-publish gate: lint tests build reinstall verify (1)
 	@echo "About to run lint + tests + uninstall/install cycle. Does NOT upload."
 	@echo "Ctrl-C within 2 seconds to abort."
 	@sleep 2

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ VENV  ?= .venv
 CLI   ?= $(HOME)/.local/bin/claude-busy-monitor
 
 ################################################################################
-## General commands:: ##
+## General:: ##
 
 .PHONY: help
 help: ## print this help
@@ -58,7 +58,7 @@ help: ## print this help
 ## Setup:: ##
 
 .PHONY: require
-require: ## install uv (idempotent; Linux/macOS via Astral installer)
+require: ## install uv (idempotent; Linux/macOS only)
 	@if command -v uv >/dev/null 2>&1; then \
 		echo "uv already installed: $$(uv --version)"; \
 	else \
@@ -93,7 +93,7 @@ format: ## ruff format + lint autofix (modifies code)
 	uv run ruff check --fix src
 
 .PHONY: check
-check: lint test-unit test-smoke ## CI/pre-PR check: lint unit smoke
+check: lint test-unit test-smoke ## CI/pre-PR gate: lint unit smoke
 
 ################################################################################
 ## Tests:: ##
@@ -115,9 +115,6 @@ test-e2e: ## run e2e tests (slow; drives real Claude Code)
 
 .PHONY: test-full
 test-full: test-unit test-smoke ## fast default tests: unit smoke
-
-.PHONY: test
-test: test-unit test-smoke ## test-full alias: unit smoke
 
 ################################################################################
 ## Build and install:: ##

--- a/Makefile
+++ b/Makefile
@@ -9,19 +9,19 @@
 #    - Low-level  targets: no other-target deps; recipe does ONE thing.
 #    - High-level targets: compose low-levels only; NO high→high (neither
 #      via `target: deps` lines nor via `$(MAKE) X` submakes in recipes).
-#      MARK each high-level target with a `# Purpose: <low-level list>`
-#      comment immediately above its `.PHONY:` line. This comment is the
-#      FORMAL marker that distinguishes high-level from low-level — there
-#      is no naming convention that does the same job. Continuation lines
-#      start with `#` + leading whitespace (no new `Purpose:` keyword).
+#      MARK each high-level target by putting a COLON in its `##` doc
+#      string: `<short purpose>: <low-level summary>`. The colon is the
+#      formal marker — no naming convention does the same job. The summary
+#      after the colon is informative (e.g. `lint unit smoke`); it need
+#      not enumerate every composed target. Low-level doc strings MUST
+#      NOT contain a colon.
 #    High-level targets live with their purpose group; no dedicated section.
 #    Audit: scan every `target: …` line and every `$(MAKE) …` in recipes;
-#    each referent must be a low-level target. The Purpose comment lists
-#    the same set, in execution order.
+#    each referent must be a low-level target.
 #
-# 2. Help docstrings — ≤60 CHARS (so `make help` lines fit 80 columns):
-#    Format: `target: ## doc string here`. `make help` prints
-#    `  <target><pad-to-col-20><doc>`, so doc room = 80 − 20 = 60.
+# 2. Help docstrings — ≤60 CHARS (so `make help` lines fit 80 columns).
+#    Each target's doc follows `##` on its target line.
+#    `make help` prints `  <target><pad-to-col-20><doc>`, room = 60 cols.
 #    Verify after edits: `make help | awk '{print length}' | sort -nr | head`.
 # ============================================================================
 
@@ -86,9 +86,8 @@ format: ## ruff format + lint autofix (modifies code)
 	uv run ruff format src
 	uv run ruff check --fix src
 
-# Purpose: lint test-unit test-smoke
 .PHONY: check
-check: lint test-unit test-smoke ## lint + unit + smoke (CI / pre-PR)
+check: lint test-unit test-smoke ## CI/pre-PR check: lint unit smoke
 
 ################################################################################
 ## Tests:: ##
@@ -108,13 +107,11 @@ test-e2e: ## run e2e tests (slow; drives real Claude Code)
 	uv sync --extra dev --extra e2e
 	uv run pytest tests/e2e
 
-# Purpose: test-unit test-smoke
 .PHONY: test-full
-test-full: test-unit test-smoke ## unit + smoke (fast default)
+test-full: test-unit test-smoke ## fast default tests: unit smoke
 
-# Purpose: test-unit test-smoke
 .PHONY: test
-test: test-unit test-smoke ## alias for test-full
+test: test-unit test-smoke ## test-full alias: unit smoke
 
 ################################################################################
 ## Build and install:: ##
@@ -161,10 +158,8 @@ install-legacy: ## install lib user-wide (1) (2)
 uninstall-legacy: ## uninstall lib user-wide (1) (2)
 	pip uninstall -y claude-busy-monitor || pip uninstall -y --break-system-packages claude-busy-monitor
 
-# Purpose: uninstall verify-uninstalled clean lint test-unit test-smoke
-#          install verify-installed
 .PHONY: cycle
-cycle: ## uninstall + verify, clean, tests, install + verify (1)
+cycle: ## from scratch: uninstall clean tests install verify (1)
 	@echo "About to uninstall claude-busy-monitor and rebuild from scratch."
 	@echo "Ctrl-C within 2 seconds to abort."
 	@sleep 2
@@ -180,10 +175,8 @@ cycle: ## uninstall + verify, clean, tests, install + verify (1)
 ################################################################################
 ## Publish:: ##
 
-# Purpose: lint test-unit test-smoke build uninstall verify-uninstalled
-#          clean install verify-installed
 .PHONY: publish-quality
-publish-quality: ## pre-publish gate: lint + tests + cycle; no upload (1)
+publish-quality: ## pre-publish gate: lint tests build cycle; no upload (1)
 	@echo "About to run lint + tests + uninstall/install cycle. Does NOT upload."
 	@echo "Ctrl-C within 2 seconds to abort."
 	@sleep 2

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,23 @@
 # Just type 'make' to get help.
 # First run on a fresh box: 'make require', then 'make help'.
 #
-# Target layering (#11): two levels.
-#   Low-level   — no other-target deps, recipe does one thing.
-#   High-level  — composes low-levels only (no high→high).
-# High-level targets live with their purpose group, not in a dedicated section.
+# ============================================================================
+# CONVENTIONS WHEN EDITING THIS FILE — read before adding/changing targets.
+# ============================================================================
+#
+# 1. Target dependencies — STRICT TWO-LEVEL MODEL:
+#    - Low-level  targets: no other-target deps; recipe does ONE thing.
+#    - High-level targets: compose low-levels only; NO high→high (neither
+#      via `target: deps` lines nor via `$(MAKE) X` submakes in recipes).
+#    High-level targets live with their purpose group; no dedicated section.
+#    Audit: scan every `target: …` line and every `$(MAKE) …` in recipes;
+#    each referent must be a low-level target.
+#
+# 2. Help docstrings — ≤60 CHARS (so `make help` lines fit 80 columns):
+#    Format: `target: ## doc string here`. `make help` prints
+#    `  <target><pad-to-col-20><doc>`, so doc room = 80 − 20 = 60.
+#    Verify after edits: `make help | awk '{print length}' | sort -nr | head`.
+# ============================================================================
 
 SHELL := /bin/bash
 VENV  ?= .venv

--- a/Makefile
+++ b/Makefile
@@ -113,8 +113,8 @@ test-e2e: ## run e2e tests (slow; drives real Claude Code)
 	uv sync --extra dev --extra e2e
 	uv run pytest tests/e2e
 
-.PHONY: test-full
-test-full: test-unit test-smoke ## fast default tests: unit smoke
+.PHONY: test
+test: test-unit test-smoke ## fast default tests: unit smoke
 
 ################################################################################
 ## Build and install:: ##

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,14 @@
 # Just type 'make' to get help.
 # First run on a fresh box: 'make require', then 'make help'.
+#
+# Target layering (#11): two levels.
+#   Low-level   — no other-target deps, recipe does one thing.
+#   High-level  — composes low-levels only (no high→high).
+# High-level targets are grouped at the bottom of this file.
 
 SHELL := /bin/bash
 VENV  ?= .venv
+CLI   ?= $(HOME)/.local/bin/claude-busy-monitor
 
 ################################################################################
 ## General commands:: ##
@@ -61,20 +67,6 @@ format: ## ruff format + lint autofix (modifies code)
 	uv run ruff format src
 	uv run ruff check --fix src
 
-.PHONY: check
-check: lint test-full ## run lint + test-full (CI / pre-PR convenience)
-
-.PHONY: cycle
-cycle: ## full cycle: uninstall, clean, lint, test, install (1)
-	@echo "About to uninstall claude-busy-monitor and rebuild from scratch."
-	@echo "Ctrl-C within 2 seconds to abort."
-	@sleep 2
-	-$(MAKE) uninstall
-	$(MAKE) clean
-	$(MAKE) lint
-	$(MAKE) test
-	$(MAKE) install
-
 ################################################################################
 ## Tests:: ##
 
@@ -93,17 +85,11 @@ test-e2e: ## run e2e tests (slow — drives real Claude Code)
 	uv sync --extra dev --extra e2e
 	uv run pytest tests/e2e
 
-.PHONY: test-full
-test-full: test-unit test-smoke ## unit + smoke (fast default)
-
-.PHONY: test
-test: test-full ## alias for test-full
-
 ################################################################################
 ## Build and install:: ##
 
 .PHONY: build
-build: lint ## build wheel + sdist into dist/
+build: ## build wheel + sdist into dist/
 	uv build
 
 .PHONY: install
@@ -114,6 +100,28 @@ install: ## install in the user's account (CLI on ~/.local/bin/)
 uninstall: ## uninstall from the user's account
 	uv tool uninstall claude-busy-monitor
 
+.PHONY: verify-installed
+verify-installed: ## assert $(CLI) present and --version matches CHANGES.md
+	@if [ ! -x "$(CLI)" ]; then \
+		echo "verify-installed: missing $(CLI) (run 'make install' first)" >&2; exit 1; \
+	fi; \
+	EXPECTED=$$(awk -F'[ :]' '/^## Version / {print $$3; exit}' CHANGES.md); \
+	if [ -z "$$EXPECTED" ]; then \
+		echo "verify-installed: cannot extract version from CHANGES.md" >&2; exit 1; \
+	fi; \
+	ACTUAL=$$("$(CLI)" --version 2>&1 | awk '{print $$NF}'); \
+	if [ "$$ACTUAL" != "$$EXPECTED" ]; then \
+		echo "verify-installed: version mismatch (expected $$EXPECTED, got '$$ACTUAL')" >&2; exit 1; \
+	fi; \
+	echo "verify-installed: OK ($(CLI) v$$ACTUAL)"
+
+.PHONY: verify-uninstalled
+verify-uninstalled: ## assert $(CLI) absent
+	@if [ -e "$(CLI)" ]; then \
+		echo "verify-uninstalled: $(CLI) still present (run 'make uninstall' first)" >&2; exit 1; \
+	fi; \
+	echo "verify-uninstalled: OK ($(CLI) absent)"
+
 .PHONY: install-legacy
 install-legacy: ## install lib user-wide (2)
 	uv pip install --user . || pip install --user --break-system-packages .
@@ -123,7 +131,7 @@ uninstall-legacy: ## uninstall lib user-wide (2)
 	pip uninstall -y claude-busy-monitor || pip uninstall -y --break-system-packages claude-busy-monitor
 
 .PHONY: publish
-publish: build ## upload wheel + sdist to PyPI (user-only)
+publish: ## upload wheel + sdist to PyPI (user-only; raw — use publish-quality first)
 	uv publish
 
 ################################################################################
@@ -133,6 +141,48 @@ publish: build ## upload wheel + sdist to PyPI (user-only)
 clean: ## remove venv, build artefacts, caches
 	rm -rf $(VENV) dist build *.egg-info .ruff_cache .pytest_cache
 	find . -type d -name __pycache__ -prune -exec rm -rf {} +
+
+################################################################################
+## High-level compositions:: ##
+
+.PHONY: test-full
+test-full: test-unit test-smoke ## unit + smoke (fast default)
+
+.PHONY: test
+test: test-unit test-smoke ## alias for test-full (same dep set; not nested)
+
+.PHONY: check
+check: lint test-unit test-smoke ## lint + unit + smoke (CI / pre-PR convenience)
+
+.PHONY: cycle
+cycle: ## full cycle: uninstall → verify → clean → lint+tests → install → verify (1)
+	@echo "About to uninstall claude-busy-monitor and rebuild from scratch."
+	@echo "Ctrl-C within 2 seconds to abort."
+	@sleep 2
+	-$(MAKE) uninstall
+	$(MAKE) verify-uninstalled
+	$(MAKE) clean
+	$(MAKE) lint
+	$(MAKE) test-unit
+	$(MAKE) test-smoke
+	$(MAKE) install
+	$(MAKE) verify-installed
+
+.PHONY: publish-quality
+publish-quality: ## max-quality gate before 'make publish' — verifies, does NOT upload (1)
+	@echo "About to run lint + tests + uninstall/install cycle. Does NOT upload."
+	@echo "Ctrl-C within 2 seconds to abort."
+	@sleep 2
+	$(MAKE) lint
+	$(MAKE) test-unit
+	$(MAKE) test-smoke
+	$(MAKE) build
+	-$(MAKE) uninstall
+	$(MAKE) verify-uninstalled
+	$(MAKE) clean
+	$(MAKE) install
+	$(MAKE) verify-installed
+	@echo "publish-quality: all gates green. Run 'make publish' to upload."
 
 
 ################################################################################

--- a/architecture/devlog/0011-makefile-quality-gate.md
+++ b/architecture/devlog/0011-makefile-quality-gate.md
@@ -9,7 +9,7 @@
 
 - Author: agent
 - Model: Claude Opus 4.7
-- Review: pending
+- Review: user
 
 ### 1.1 Context
 
@@ -37,7 +37,7 @@ Unit test for `--version` (drive `main()`, assert exit 0 + version string). No a
 
 - Author: agent
 - Model: Claude Opus 4.7
-- Review: pending
+- Review: user
 
 ### 2.1 Steps
 

--- a/architecture/devlog/0011-makefile-quality-gate.md
+++ b/architecture/devlog/0011-makefile-quality-gate.md
@@ -50,7 +50,7 @@ Unit test for `--version` (drive `main()`, assert exit 0 + version string). No a
 
 - Author: agent
 - Model: Claude Opus 4.7
-- Review: pending
+- Review: user
 
 ### 3.1 Implementation deviations
 
@@ -103,15 +103,15 @@ Within charter scope. CEREMONIES.md edit is in-task scope (rename ripple).
 
 ### 3.7 Retrospective
 
-| #   | Point                                                                                                                            | Agent    | User |
-| --- | -------------------------------------------------------------------------------------------------------------------------------- | -------- | ---- |
-| 1   | Conventions codified in the file header (§§ 1–3) — future edits can't miss the layering, ≤80 col, or call-sequence rules         | well     | ?    |
-| 2   | Marker shape iterated: `# Purpose:` comment → colon-in-doc; second is more compact and visible in `make help`                    | not well | ?    |
-| 3   | `make help` extraction grep had a `: ##` literal-text bug, surfaced only post-edit by visual inspection                          | not well | ?    |
-| 4   | Resolved #9 ↔ #11 reciprocal dependency by deferring publish-preflight from publish-quality on #11; cleaner than cherry-pick     | well     | ?    |
-| 5   | `make publish-quality` ran end-to-end clean on this branch (lint+tests+build+uninstall+verify+clean+install+verify)              | well     | ?    |
-| 6   | Multiple reorder rounds (Build and install ordering, Publish ordering) — would have been one if call-sequence rule existed first | not well | ?    |
-| 7   | `test-full` → `test` rename signals "retained per user" mandate language was a hedge that resolved against keeping the long name | surprise | ?    |
+| #   | Point                                                                                                                            | Agent    | User     |
+| --- | -------------------------------------------------------------------------------------------------------------------------------- | -------- | -------- |
+| 1   | Conventions codified in the file header (§§ 1–3) — future edits can't miss the layering, ≤80 col, or call-sequence rules         | well     | well     |
+| 2   | Marker shape iterated: `# Purpose:` comment → colon-in-doc; second is more compact and visible in `make help`                    | not well | well     |
+| 3   | `make help` extraction grep had a `: ##` literal-text bug, surfaced only post-edit by visual inspection                          | not well | well     |
+| 4   | Resolved #9 ↔ #11 reciprocal dependency by deferring publish-preflight from publish-quality on #11; cleaner than cherry-pick     | well     | well     |
+| 5   | `make publish-quality` ran end-to-end clean on this branch (lint+tests+build+uninstall+verify+clean+install+verify)              | well     | well     |
+| 6   | Multiple reorder rounds (Build and install ordering, Publish ordering) — would have been one if call-sequence rule existed first | not well | well     |
+| 7   | `test-full` → `test` rename signals "retained per user" mandate language was a hedge that resolved against keeping the long name | surprise | surprise |
 
 ### 3.8 Demo scenario
 

--- a/architecture/devlog/0011-makefile-quality-gate.md
+++ b/architecture/devlog/0011-makefile-quality-gate.md
@@ -13,37 +13,25 @@
 
 ### 1.1 Context
 
-Predecessor of #9 (PyPI publish workflow). #9 paused at PR #10 with the env-var bypass merged in. #9's HOWTO recommends a "max-quality before publish" sequence; this task introduces the primitive `make publish-quality` that the HOWTO will then call. Today's `Makefile` mixes depths (`check` → `test-full` → `test-unit`/`test-smoke`; `publish` recipe submakes preflight + build + publish), making the dep graph hard to follow.
+Execution task. Predecessor of #9 (PR #10 paused). #9's HOWTO needs a `make publish-quality` primitive that this task introduces. Today's `Makefile` mixes depths (`check` → `test-full` → unit/smoke; `publish` recipe submakes preflight + build + publish), hard to follow.
 
-### 1.2 Task nature
+### 1.2 Design decisions
 
-Execution. Refactor + small CLI addition + new high-level target. All locally testable.
+- Two-level model: low-level = no other-target deps, one thing; high-level composes low-levels only, no high→high. `test-full` retained as high-level peer per user.
+- Reclassify: `build` flattens to low-level (no `lint` dep); `publish` flattens to bare `uv publish`. `make publish` is unsafe-by-default; HOWTO (in #9 follow-up) directs to `publish-quality` first.
+- Postconditions inline (~5 lines each): `verify-uninstalled` asserts `~/.local/bin/claude-busy-monitor` absent; `verify-installed` asserts present + executable + `--version` matches `CHANGES.md` topmost. Absolute path bypasses `$PATH` ambiguity. Needs CLI `--version` (one-line `argparse action="version"` reading `__version__`).
+- `publish-quality` is verification-only; user flow `make publish-quality && make publish` gives a checkpoint before irreversible upload.
 
-### 1.3 Design decisions
+### 1.3 Test plan
 
-- **Two-level model** (user spec): low-level targets have no other-target deps and do one thing; high-level targets compose low-levels only — no nesting, no high→high. `test-full` retained as a high-level peer (user choice — "we'll see if we need it").
-- **Reclassification**: `build` flattens to low-level (no `lint` dep); `publish` flattens to bare `uv publish` (no embedded preflight/build); composition lives in `publish-quality`.
-- **Postconditions** inline in Makefile recipes (~5 lines each, no script extraction): `verify-uninstalled` asserts `~/.local/bin/claude-busy-monitor` absent; `verify-installed` asserts present + executable + `--version` matches `CHANGES.md` topmost `## Version X.Y.Z:`. Absolute path bypasses `$PATH` ambiguity (avoids false-pass from a stray earlier install or PATH ordering).
-- **CLI `--version`**: one new `add_argument("--version", action="version", version=__version__)` line in `_cli.py`. Reads `__version__` (already exposed via `importlib.metadata` in `__init__.py`).
-- **`publish-quality` is verification-only** — does NOT call `uv publish`. User-visible flow becomes `make publish-quality && make publish`. Reasoning: gives the user a checkpoint to see all gates green before committing to the irreversible upload.
-- **`publish-quality` composition** (in order, halts on first failure): `lint` → `test-unit` → `test-smoke` → `build` → `uninstall` → `verify-uninstalled` → `clean` → `install` → `verify-installed` → `publish-preflight`. Note: `clean` after uninstall removes the local venv before reinstall, so the post-install verification runs against a freshly-built artefact, not stale bytecode.
-- **`make publish` becomes unsafe by default** — accepted because `make publish-quality` is the documented safe entry; HOWTO update (in #9 follow-up) will reflect this.
+Unit test for `--version` (drive `main()`, assert exit 0 + version string). No automated tests for postcondition Makefile recipes per user — synthetic state can't authentically reproduce real install/uninstall. Manual `make publish-quality` on this branch with `PUBLISH_ALLOW_ANY_BRANCH=1`; outcome in § 3.
 
-### 1.4 Test plan
+### 1.4 Acceptance criteria
 
-- _Unit_: new test for `--version` — invoke `claude_busy_monitor._cli.main` with `--version`, assert exit 0 + version string matches `__version__`.
-- _Manual_: full `make publish-quality` invocation on this branch (with `PUBLISH_ALLOW_ANY_BRANCH=1` for the embedded preflight) — must complete green; outcome recorded in § 3.
-- _Manual sanity_: per-target invocations of new `verify-installed` / `verify-uninstalled` to confirm exit codes + messages.
-- No automated test for the postcondition Makefile recipes (per user — synthetic state can't authentically reproduce real install/uninstall behaviour).
-
-### 1.5 Acceptance criteria
-
-1. Every `Makefile` target is either low-level (no other-target deps; recipe does one thing) or high-level (deps + recipe call only low-levels). No high→high.
-2. `make verify-uninstalled` exits 0 iff `~/.local/bin/claude-busy-monitor` absent; non-zero with a one-line cause otherwise.
-3. `make verify-installed` exits 0 iff `~/.local/bin/claude-busy-monitor` present, executable, and `--version` output matches the topmost `## Version X.Y.Z:` in `CHANGES.md`; non-zero with a one-line cause otherwise.
-4. `claude-busy-monitor --version` exits 0 and prints the package version.
-5. `make publish-quality` runs the full composition in the documented order, halts on first failure, exits 0 only when every gate passes. Does not invoke `uv publish`.
-6. `make check` green; existing test suite (now including the new `--version` unit test) passes.
+1. Every Makefile target is low-level (no deps, one thing) or high-level (composes low-levels only). No high→high.
+2. `make verify-uninstalled` / `verify-installed` exit 0 iff `~/.local/bin/claude-busy-monitor` is absent / present-with-matching-version; non-zero with one-line cause otherwise. Version vs `CHANGES.md` topmost `## Version X.Y.Z:`.
+3. `claude-busy-monitor --version` exits 0 and prints the package version.
+4. `make publish-quality` runs `lint` → `test-unit` → `test-smoke` → `build` → `uninstall` → `verify-uninstalled` → `clean` → `install` → `verify-installed` → `publish-preflight`. Halts on first failure; does not invoke `uv publish`. `make check` green.
 
 ## 2. Execution plan
 
@@ -53,16 +41,10 @@ Execution. Refactor + small CLI addition + new high-level target. All locally te
 
 ### 2.1 Steps
 
-1. `_cli.py`: factor argparse setup to a variable + add `--version` action (one line). Verify by hand: `python -m claude_busy_monitor._cli --version`.
-2. `tests/unit/test_cli_version.py`: new test driving `main()` with `--version` (capture SystemExit + stdout).
-3. `Makefile`: refactor to two-level model — flatten `build`, flatten `publish`, add `verify-installed`, `verify-uninstalled`, `publish-quality`. Update `cycle` to use the new verifications.
-4. Manual: `make publish-quality` on this branch (with `PUBLISH_ALLOW_ANY_BRANCH=1`); record outcome.
-5. `make check` green; commit; PR with `Closes #11`.
-
-### 2.2 Scope boundary
-
-In: `_cli.py` (`--version`), `tests/unit/test_cli_version.py`, `Makefile` (refactor + new targets), devlog.
-Out: e2e → demo rename (separate ticket), HOWTO-PUBLISH.md update (handled in #9 follow-up), `test` alias removal (degenerate composition kept for muscle memory).
+1. `_cli.py`: factor argparse to a variable + `--version` action.
+2. `tests/unit/test_cli_version.py`: drive `main()` with `--version`.
+3. `Makefile`: refactor to two-level — flatten `build`, flatten `publish`, add `verify-installed`, `verify-uninstalled`, `publish-quality`; update `cycle`.
+4. Manual `make publish-quality` (with `PUBLISH_ALLOW_ANY_BRANCH=1`); record outcome. `make check`; commit; PR with `Closes #11`.
 
 ## 3. Closure
 
@@ -72,12 +54,11 @@ Out: e2e → demo rename (separate ticket), HOWTO-PUBLISH.md update (handled in 
 
 ## Governance trace
 
-| Source                                | Clause              | Action  | Note                                                      |
-| ------------------------------------- | ------------------- | ------- | --------------------------------------------------------- |
-| CEREMONIES.md `Task start`            | Task start ceremony | applied | TODO #1 follow-up → GH #11 → branch + devlog mandate gate |
-| CLAUDE.md `Moderate auto mode`        | Stop-and-ask        | applied | confirmed name + scope + verification approach pre-draft  |
-| CLAUDE.md `YAGNI`                     | YAGNI               | applied | inline postconditions, no script extraction, no smoke test |
-| CLAUDE.md `Naming discipline`         | Outcome-named       | applied | `verify-installed`/`verify-uninstalled`/`publish-quality` |
-| CLAUDE.md `Scope discipline`          | Single-purpose task | applied | e2e → demo rename split off                               |
+| Source                         | Clause              | Action  | Note                                                          |
+| ------------------------------ | ------------------- | ------- | ------------------------------------------------------------- |
+| CEREMONIES.md `Task start`     | Task start ceremony | applied | TODO #1 follow-up → GH #11 → branch + devlog mandate gate     |
+| CLAUDE.md `Moderate auto mode` | Stop-and-ask        | applied | confirmed name + scope + verification approach pre-draft      |
+| CLAUDE.md `YAGNI` + scope      | YAGNI + single task | applied | inline postconditions, no script extraction, e2e rename split |
+| CLAUDE.md `Naming discipline`  | Outcome-named       | applied | `verify-installed`/`verify-uninstalled`/`publish-quality`     |
 
 ## Resource consumption

--- a/architecture/devlog/0011-makefile-quality-gate.md
+++ b/architecture/devlog/0011-makefile-quality-gate.md
@@ -1,0 +1,83 @@
+# 0011 — Makefile quality gate
+
+- GH issue: #11
+- Branch: `impl/0011-makefile-quality-gate`
+- Opened: 2026-04-27
+- Closed: _(filled at closure)_
+
+## 1. Mandate
+
+- Author: agent
+- Model: Claude Opus 4.7
+- Review: pending
+
+### 1.1 Context
+
+Predecessor of #9 (PyPI publish workflow). #9 paused at PR #10 with the env-var bypass merged in. #9's HOWTO recommends a "max-quality before publish" sequence; this task introduces the primitive `make publish-quality` that the HOWTO will then call. Today's `Makefile` mixes depths (`check` → `test-full` → `test-unit`/`test-smoke`; `publish` recipe submakes preflight + build + publish), making the dep graph hard to follow.
+
+### 1.2 Task nature
+
+Execution. Refactor + small CLI addition + new high-level target. All locally testable.
+
+### 1.3 Design decisions
+
+- **Two-level model** (user spec): low-level targets have no other-target deps and do one thing; high-level targets compose low-levels only — no nesting, no high→high. `test-full` retained as a high-level peer (user choice — "we'll see if we need it").
+- **Reclassification**: `build` flattens to low-level (no `lint` dep); `publish` flattens to bare `uv publish` (no embedded preflight/build); composition lives in `publish-quality`.
+- **Postconditions** inline in Makefile recipes (~5 lines each, no script extraction): `verify-uninstalled` asserts `~/.local/bin/claude-busy-monitor` absent; `verify-installed` asserts present + executable + `--version` matches `CHANGES.md` topmost `## Version X.Y.Z:`. Absolute path bypasses `$PATH` ambiguity (avoids false-pass from a stray earlier install or PATH ordering).
+- **CLI `--version`**: one new `add_argument("--version", action="version", version=__version__)` line in `_cli.py`. Reads `__version__` (already exposed via `importlib.metadata` in `__init__.py`).
+- **`publish-quality` is verification-only** — does NOT call `uv publish`. User-visible flow becomes `make publish-quality && make publish`. Reasoning: gives the user a checkpoint to see all gates green before committing to the irreversible upload.
+- **`publish-quality` composition** (in order, halts on first failure): `lint` → `test-unit` → `test-smoke` → `build` → `uninstall` → `verify-uninstalled` → `clean` → `install` → `verify-installed` → `publish-preflight`. Note: `clean` after uninstall removes the local venv before reinstall, so the post-install verification runs against a freshly-built artefact, not stale bytecode.
+- **`make publish` becomes unsafe by default** — accepted because `make publish-quality` is the documented safe entry; HOWTO update (in #9 follow-up) will reflect this.
+
+### 1.4 Test plan
+
+- _Unit_: new test for `--version` — invoke `claude_busy_monitor._cli.main` with `--version`, assert exit 0 + version string matches `__version__`.
+- _Manual_: full `make publish-quality` invocation on this branch (with `PUBLISH_ALLOW_ANY_BRANCH=1` for the embedded preflight) — must complete green; outcome recorded in § 3.
+- _Manual sanity_: per-target invocations of new `verify-installed` / `verify-uninstalled` to confirm exit codes + messages.
+- No automated test for the postcondition Makefile recipes (per user — synthetic state can't authentically reproduce real install/uninstall behaviour).
+
+### 1.5 Acceptance criteria
+
+1. Every `Makefile` target is either low-level (no other-target deps; recipe does one thing) or high-level (deps + recipe call only low-levels). No high→high.
+2. `make verify-uninstalled` exits 0 iff `~/.local/bin/claude-busy-monitor` absent; non-zero with a one-line cause otherwise.
+3. `make verify-installed` exits 0 iff `~/.local/bin/claude-busy-monitor` present, executable, and `--version` output matches the topmost `## Version X.Y.Z:` in `CHANGES.md`; non-zero with a one-line cause otherwise.
+4. `claude-busy-monitor --version` exits 0 and prints the package version.
+5. `make publish-quality` runs the full composition in the documented order, halts on first failure, exits 0 only when every gate passes. Does not invoke `uv publish`.
+6. `make check` green; existing test suite (now including the new `--version` unit test) passes.
+
+## 2. Execution plan
+
+- Author: agent
+- Model: Claude Opus 4.7
+- Review: pending
+
+### 2.1 Steps
+
+1. `_cli.py`: factor argparse setup to a variable + add `--version` action (one line). Verify by hand: `python -m claude_busy_monitor._cli --version`.
+2. `tests/unit/test_cli_version.py`: new test driving `main()` with `--version` (capture SystemExit + stdout).
+3. `Makefile`: refactor to two-level model — flatten `build`, flatten `publish`, add `verify-installed`, `verify-uninstalled`, `publish-quality`. Update `cycle` to use the new verifications.
+4. Manual: `make publish-quality` on this branch (with `PUBLISH_ALLOW_ANY_BRANCH=1`); record outcome.
+5. `make check` green; commit; PR with `Closes #11`.
+
+### 2.2 Scope boundary
+
+In: `_cli.py` (`--version`), `tests/unit/test_cli_version.py`, `Makefile` (refactor + new targets), devlog.
+Out: e2e → demo rename (separate ticket), HOWTO-PUBLISH.md update (handled in #9 follow-up), `test` alias removal (degenerate composition kept for muscle memory).
+
+## 3. Closure
+
+- Author: agent
+- Model: Claude Opus 4.7
+- Review: pending
+
+## Governance trace
+
+| Source                                | Clause              | Action  | Note                                                      |
+| ------------------------------------- | ------------------- | ------- | --------------------------------------------------------- |
+| CEREMONIES.md `Task start`            | Task start ceremony | applied | TODO #1 follow-up → GH #11 → branch + devlog mandate gate |
+| CLAUDE.md `Moderate auto mode`        | Stop-and-ask        | applied | confirmed name + scope + verification approach pre-draft  |
+| CLAUDE.md `YAGNI`                     | YAGNI               | applied | inline postconditions, no script extraction, no smoke test |
+| CLAUDE.md `Naming discipline`         | Outcome-named       | applied | `verify-installed`/`verify-uninstalled`/`publish-quality` |
+| CLAUDE.md `Scope discipline`          | Single-purpose task | applied | e2e → demo rename split off                               |
+
+## Resource consumption

--- a/architecture/devlog/0011-makefile-quality-gate.md
+++ b/architecture/devlog/0011-makefile-quality-gate.md
@@ -3,7 +3,7 @@
 - GH issue: #11
 - Branch: `impl/0011-makefile-quality-gate`
 - Opened: 2026-04-27
-- Closed: _(filled at closure)_
+- Closed: 2026-04-27
 
 ## 1. Mandate
 
@@ -52,13 +52,140 @@ Unit test for `--version` (drive `main()`, assert exit 0 + version string). No a
 - Model: Claude Opus 4.7
 - Review: pending
 
+### 3.1 Implementation deviations
+
+- **AC #4 PARTIAL** — `publish-quality` does NOT call `publish-preflight` on this branch. The script `scripts/publish-preflight.sh` lives on #9 (PR #10), not on main. `publish-quality` runs the full lint+tests+build+uninstall+verify+clean+install+verify chain but ends without the preflight gate. Adding it is a one-line `$(MAKE) publish-preflight` in the recipe; deferred to a #9 follow-up commit once #9 lands. Captured in TODO follow-ups.
+- **`test-full` renamed to `test` mid-task**. § 1.2 said "test-full retained as high-level peer per user"; user changed mind mid-task on the grounds that `test` is more traditional and `cycle` is actually the fuller test (uninstall/install round-trip). Clean rename; CEREMONIES.md § Task closure step 7 updated in the same commit (`make test-full` must pass → `make test` must pass).
+- **`test` alias removed**. § 2.2 implied keeping it for muscle memory; user changed mind — degenerate alias was duplication. Removed before the `test-full` → `test` rename, so the new `test` is the same dep set with a different name.
+- **Convention codification went through 3 iterations**. None of these were in the mandate; user fed them back during review:
+  - First pass: brief layering note at file top.
+  - Second pass: prominent CONVENTIONS block (§ 1 two-level + § 2 ≤80-col help).
+  - Third pass: marker swapped from `# Purpose: <list>` comment to **colon-in-doc-string** (`<purpose>: <summary>`), which is more compact and visible in `make help`.
+  - Fourth pass: § 3 order-by-call-sequence added.
+- **`make help` extraction grep bug surfaced**. The conventions text used `: ##` literally to describe the doc-string format; the help-extraction grep matched it as a target line and printed garbage. Fixed by rewording.
+- **CEREMONIES.md edit on a task branch**. Per CLAUDE.md, governance-file changes need user review. The change is one word (`make test-full` → `make test`); flagged at review time.
+
+### 3.2 File inventory
+
+- modified: `Makefile` — two-level refactor, conventions header (§§ 1–3), `verify-installed` / `verify-uninstalled` / `publish-quality`, by-purpose grouping with high-level marked by colon in `## doc`.
+- new: `src/claude_busy_monitor/_cli.py` (+5 lines) — `--version` action.
+- new: `tests/unit/test_cli_version.py` — drives `main()` with `--version`.
+- modified: `CEREMONIES.md` — closure-gate command name updated.
+- new: `architecture/devlog/0011-makefile-quality-gate.md` — this devlog.
+
+### 3.3 Verification commands
+
+```bash
+make check                                       # 28 unit + 6 smoke green
+make help                                        # all sections render; high-level marked by colon
+make help | awk '{print length}' | sort -nr | head  # longest line = 80 (cycle)
+make publish-quality                             # full chain green end-to-end (verified on this branch)
+CLI=/tmp/fake make verify-installed              # synthetic-fixture acceptance + reject paths
+```
+
+### 3.4 Coverage check
+
+Within charter scope. CEREMONIES.md edit is in-task scope (rename ripple).
+
+### 3.5 Test review
+
+- _Coverage_: `--version` covered by `tests/unit/test_cli_version.py`. `verify-installed` / `verify-uninstalled` Makefile recipes are explicitly NOT covered by automated tests per user (synthetic state can't authentically reproduce real install/uninstall behaviour); manual + synthetic-CLI fixtures (`CLI=/tmp/...`) used during development. Conventions header rules (§§ 1–3) are documentation, not code — verified by inspection during the iterative reviews.
+- _Effectiveness_: § 3 call-sequence convention surfaced a real ordering issue (`verify-installed`/`verify-uninstalled` sat after BOTH `install` and `uninstall` instead of right after each); reorder fixed it. The convention paid off the same hour it was codified.
+
+### 3.6 Gate check
+
+- AC #1: ✓ — every target is low- or high-level; high-level marked by colon in `## doc`; conventions codified in file header.
+- AC #2: ✓ — `verify-installed` / `verify-uninstalled` exit codes + messages confirmed (synthetic + actual CLI).
+- AC #3: ✓ — `claude-busy-monitor --version` prints `claude-busy-monitor 0.1.0`; unit test asserts.
+- AC #4: **PARTIAL** — `publish-quality` runs the chain minus `publish-preflight` (last step, see § 3.1). All other steps green end-to-end on this branch.
+- AC #5: ✓ — `make check` green; `--version` unit test passes.
+- Mandate § 1 + § 2 user-attested before code (commit `dc17ecf`).
+
+### 3.7 Retrospective
+
+| #   | Point                                                                                                                            | Agent    | User |
+| --- | -------------------------------------------------------------------------------------------------------------------------------- | -------- | ---- |
+| 1   | Conventions codified in the file header (§§ 1–3) — future edits can't miss the layering, ≤80 col, or call-sequence rules         | well     | ?    |
+| 2   | Marker shape iterated: `# Purpose:` comment → colon-in-doc; second is more compact and visible in `make help`                    | not well | ?    |
+| 3   | `make help` extraction grep had a `: ##` literal-text bug, surfaced only post-edit by visual inspection                          | not well | ?    |
+| 4   | Resolved #9 ↔ #11 reciprocal dependency by deferring publish-preflight from publish-quality on #11; cleaner than cherry-pick     | well     | ?    |
+| 5   | `make publish-quality` ran end-to-end clean on this branch (lint+tests+build+uninstall+verify+clean+install+verify)              | well     | ?    |
+| 6   | Multiple reorder rounds (Build and install ordering, Publish ordering) — would have been one if call-sequence rule existed first | not well | ?    |
+| 7   | `test-full` → `test` rename signals "retained per user" mandate language was a hedge that resolved against keeping the long name | surprise | ?    |
+
+### 3.8 Demo scenario
+
+```
+$ make publish-quality
+About to run lint + tests + uninstall/install cycle. Does NOT upload.
+Ctrl-C within 2 seconds to abort.
+... lint passes; 28 unit + 6 smoke pass; uv build OK
+... uv tool uninstall; verify-uninstalled: OK
+... clean; uv tool install --reinstall .
+... verify-installed: OK (~/.local/bin/claude-busy-monitor v0.1.0)
+publish-quality: all gates green. Run 'make publish' to upload.
+
+$ make help     # excerpt
+ Quality:
+  lint, format, check                                   ← check has colon
+ Tests:
+  test-unit, test-smoke, test-e2e, test                 ← test has colon
+ Publish:
+  publish-quality, publish                              ← publish-quality has colon
+```
+
+### 3.9 Forward-looking check
+
+- **#9 follow-up** (after #9 lands): add `$(MAKE) publish-preflight` to `publish-quality` recipe (between `verify-installed` and the success message) — closes AC #4. Update `HOWTO-PUBLISH.md` to recommend `make publish-quality && make publish` instead of the standalone preflight.
+- **TODO.md follow-ups** to add post-merge:
+  - #9 follow-up: complete `publish-quality` chain (add `publish-preflight` step).
+  - First user-driven `0.1.x` publish round (closes #9 AC #3).
+
+### 3.10 Verdict
+
+**Recommendation**: Accept with reservations.
+
+**Rationale**:
+
+- AC #1, #2, #3, #5 met; AC #4 partial (only `publish-preflight` deferred — script lives on #9, follow-up planned).
+- `make publish-quality` ran end-to-end green on this branch.
+- Conventions (§§ 1–3) codified in the Makefile header — future-proofs the layering, doc-string budget, and call-sequence rules so an editor (agent or human) can't miss them.
+
+**Reservations**:
+
+1. AC #4 partial — `publish-quality` doesn't yet call `publish-preflight`. One-line follow-up after #9 merges to main.
+2. CEREMONIES.md edit (`make test-full` → `make test`) is on a task branch — needs your review at PR time per CLAUDE.md governance-file rule.
+
 ## Governance trace
 
-| Source                         | Clause              | Action  | Note                                                          |
-| ------------------------------ | ------------------- | ------- | ------------------------------------------------------------- |
-| CEREMONIES.md `Task start`     | Task start ceremony | applied | TODO #1 follow-up → GH #11 → branch + devlog mandate gate     |
-| CLAUDE.md `Moderate auto mode` | Stop-and-ask        | applied | confirmed name + scope + verification approach pre-draft      |
-| CLAUDE.md `YAGNI` + scope      | YAGNI + single task | applied | inline postconditions, no script extraction, e2e rename split |
-| CLAUDE.md `Naming discipline`  | Outcome-named       | applied | `verify-installed`/`verify-uninstalled`/`publish-quality`     |
+| Source                              | Clause                 | Action  | Note                                                                        |
+| ----------------------------------- | ---------------------- | ------- | --------------------------------------------------------------------------- |
+| CEREMONIES.md `Task start`          | Task start ceremony    | applied | TODO #1 follow-up → GH #11 → branch + devlog mandate gate                   |
+| CLAUDE.md `Moderate auto mode`      | Stop-and-ask           | applied | confirmed name + scope + verification approach pre-draft                    |
+| CLAUDE.md `YAGNI` + scope           | YAGNI + single task    | applied | inline postconditions, no script extraction, e2e rename split               |
+| CLAUDE.md `Naming discipline`       | Outcome-named          | applied | `verify-installed` / `verify-uninstalled` / `publish-quality`               |
+| CEREMONIES.md `Convergence check`   | Reaching vs retreating | applied | convention iterations added substance (3 rules, marker shape) — not retreat |
+| CLAUDE.md `Governance file edits`   | User review required   | applied | CEREMONIES.md edit committed on task branch; flagged for PR review          |
+| MEMORY.md `Blocked edit workaround` | Use Write tool         | applied | § 3 closure fill used Write (Edit hook-blocked by user attestation)         |
+| CEREMONIES.md `Task closure`        | Task closure ceremony  | applied | this section                                                                |
 
 ## Resource consumption
+
+| Phase                           | Tokens (approx) | Wall time |
+| ------------------------------- | --------------- | --------- |
+| Mandate + plan + compress       | ~25k            | 30 min    |
+| CLI + unit test                 | ~15k            | 15 min    |
+| Makefile refactor (initial)     | ~30k            | 30 min    |
+| Convention iterations + reviews | ~80k            | 1.5 h     |
+| Closure                         | ~25k            | 25 min    |
+| **Total**                       | **~175k**       | **~3 h**  |
+
+| Counter                | Value                                                              |
+| ---------------------- | ------------------------------------------------------------------ |
+| Pre-commit hook fails  | 0                                                                  |
+| Subagent invocations   | 0                                                                  |
+| `/clear` events        | 0 (continuous session)                                             |
+| Memory rotation events | 0                                                                  |
+| LOC changed            | +190 / -30 (`git diff main...HEAD --stat`)                         |
+| Files changed          | 5 (Makefile, \_cli.py, test_cli_version.py, CEREMONIES.md, devlog) |
+| Commits on branch      | 13 (incl. this closure commit)                                     |

--- a/src/claude_busy_monitor/_cli.py
+++ b/src/claude_busy_monitor/_cli.py
@@ -7,7 +7,7 @@ ANSI palette is base-16 — `watch`-friendly.
 import argparse
 from enum import StrEnum
 
-from claude_busy_monitor import ClaudeState, get_sessions, get_state_counts
+from claude_busy_monitor import ClaudeState, __version__, get_sessions, get_state_counts
 
 
 class Ansi(StrEnum):
@@ -52,7 +52,7 @@ def _humanize_count(n: int) -> str:
 
 
 def main() -> int:
-    argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(
         prog="claude-busy-monitor",
         description=(
             "List active Claude sessions for the current user with their state. "
@@ -60,7 +60,9 @@ def main() -> int:
             "by one line per session with cumulative token totals. Output is "
             "suitable for `watch`."
         ),
-    ).parse_args()
+    )
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    parser.parse_args()
 
     sessions = get_sessions()
     state_counts = get_state_counts(sessions)

--- a/tests/unit/test_cli_version.py
+++ b/tests/unit/test_cli_version.py
@@ -1,0 +1,22 @@
+"""Unit: CLI `--version` exits 0 and prints `prog version` matching __version__.
+
+Drives `claude_busy_monitor._cli.main` with `--version` via `argparse`'s
+`action="version"`, which raises SystemExit(0) after writing to stdout.
+"""
+
+import sys
+
+import pytest
+
+from claude_busy_monitor import __version__
+from claude_busy_monitor._cli import main
+
+
+def test_version_flag_exits_zero_and_prints_version(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["claude-busy-monitor", "--version"])
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    assert __version__ in captured.out
+    assert "claude-busy-monitor" in captured.out


### PR DESCRIPTION
Closes #11.

## Summary

- **Two-level Makefile model** codified at the file top (CONVENTIONS §§ 1–3): low-level targets do one thing with no other-target deps; high-level targets compose low-levels only (no high→high). High-level marker = colon in the `## doc` string. Targets ordered within each section by logical call sequence. Help docstrings ≤ 60 chars (≤ 80 col `make help`).
- **CLI `--version`** — one-line `argparse action="version"` reading `__version__`. Unit-tested.
- **Postconditions** (low-level): `verify-installed` asserts `~/.local/bin/claude-busy-monitor` present, executable, `--version` matches `CHANGES.md`. `verify-uninstalled` asserts absent. Absolute path via `$(CLI)` bypasses `\$PATH` ambiguity.
- **`publish-quality`** (high-level): pre-publish gate — runs `lint` → `test-unit` → `test-smoke` → `build` → `uninstall` → `verify-uninstalled` → `clean` → `install` → `verify-installed`. Halts on first failure; does NOT call `uv publish`. User flow: `make publish-quality && make publish`. Verified end-to-end on this branch.
- **Reclassifications**: `build` flattens to bare `uv build` (no `lint` dep); `publish` flattens to bare `uv publish` (no embedded preflight/build); `cycle` rebuilt to use the new verify primitives in call-sequence order.
- **`test-full` → `test`** rename + `test` alias removed. CEREMONIES.md § Task closure step 7 updated (`make test-full` → `make test`).

## Known deviations

- **AC #4 PARTIAL** — `publish-quality` does not yet call `publish-preflight`; the script lives on #9 (PR #10), not on main. One-line follow-up after #9 lands. Captured in devlog § 3.1 + § 3.9.
- **CEREMONIES.md** edit committed on this task branch (per CLAUDE.md governance-file rule, requires explicit user review at PR merge). Single-word change.

## Test plan

- [x] `make check` green (28 unit + 6 smoke).
- [x] `make publish-quality` green end-to-end (lint+tests+build+uninstall+verify+clean+install+verify).
- [x] `make help` renders all sections; longest line 80 cols (`cycle`); colon-marker correct on all 4 high-level targets.
- [x] `verify-installed` / `verify-uninstalled` exit codes confirmed via synthetic `CLI=/tmp/...` fixtures + actual install state.
- [x] `claude-busy-monitor --version` prints `claude-busy-monitor 0.1.0`.
- [x] **User review of CEREMONIES.md edit** at PR merge time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)