### PR TITLE
[impl] README: split programmer reference into README-LIBRARY.md (v1.0.3)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+## Version 1.0.3:
+
+- README split: programmer-facing API and `make` target reference moved to new `README-LIBRARY.md`. Main README's Library subsection slimmed to a short example plus a link.
+- README polish: numbered headings (level 2 and 3); macOS and `~/.claude/sessions/` mentions deduped; em-dashes replaced with `;` / `:` / parentheses; Features table dropped the redundant "No daemon, no IPC" row (already in Scope); Compatibility macOS bullet compressed to two lines.
+- README example bug fix: `s.cwd` / `s.session_id` → `s.path` / `s.id`. The dataclass exposes `path` and `id`; the prior example would `AttributeError` at runtime.
+- Makefile `require` target description: "Linux/macOS only" → "Linux only" (matches the Compatibility statement).
+
 ## Version 1.0.2:
 
 - README install section restructured by user intent: **As a command** (recommends `pipx install` / `uv tool install` — isolated per-tool venv, no PEP 668 grief), **As a library** (`pip install` in project venv), **From source** (contributors). The previous wording suggested bare `pip install claude-busy-monitor` which fails on modern PEP 668-marked distros (Debian 12+, Ubuntu 23+, etc.).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - README split: programmer-facing API and `make` target reference moved to new `README-LIBRARY.md`. Main README's Library subsection slimmed to a short example plus a link.
 - README polish: numbered headings (level 2 and 3); macOS and `~/.claude/sessions/` mentions deduped; em-dashes replaced with `;` / `:` / parentheses; Features table dropped the redundant "No daemon, no IPC" row (already in Scope); Compatibility macOS bullet compressed to two lines.
 - README example bug fix: `s.cwd` / `s.session_id` → `s.path` / `s.id`. The dataclass exposes `path` and `id`; the prior example would `AttributeError` at runtime.
+- Library: improved/added docstrings on `ClaudeState`, `TokenStats`, `ClaudeSession`, `get_sessions`, `get_state_counts` (visible via `help()` and IDE hover). README-LIBRARY.md § 1 mirrors them as a fenced declarations block instead of a paraphrased table, so drift is easier to spot.
 - Makefile `require` target description: "Linux/macOS only" → "Linux only" (matches the Compatibility statement).
 
 ## Version 1.0.2:

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ help: ## print this help
 ## Setup:: ##
 
 .PHONY: require
-require: ## install uv (idempotent; Linux/macOS only)
+require: ## install uv (idempotent; Linux only)
 	@if command -v uv >/dev/null 2>&1; then \
 		echo "uv already installed: $$(uv --version)"; \
 	else \

--- a/README-LIBRARY.md
+++ b/README-LIBRARY.md
@@ -99,7 +99,7 @@ TARGETs:
   help               print this help
 
  Setup:
-  require            install uv (idempotent; Linux)
+  require            install uv (idempotent; Linux only)
   venv-activate      start an interactive shell in updated .venv
 
  Quality:

--- a/README-LIBRARY.md
+++ b/README-LIBRARY.md
@@ -5,15 +5,68 @@ For installation and an overview, see [README.md](README.md).
 
 ## 1. Library API
 
-Public names exported from `claude_busy_monitor`:
+Public names exported from `claude_busy_monitor`.
 
-| Name                              | Kind      | Synopsis                                                                                                                                                                                   |
-| --------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `ClaudeState`                     | Enum      | `BUSY`, `ASKING`, `IDLE`. `str(state)` is the lower-case name.                                                                                                                             |
-| `TokenStats`                      | dataclass | Cumulative token totals: `output: int`, `input: int` (input sums fresh, cache-create, cache-read).                                                                                         |
-| `ClaudeSession`                   | dataclass | One live session: `path: str` (cwd of the claude process), `name: str` (basename of `path`), `id: str` (session UUID; `""` if unknown), `state: ClaudeState`, `stats: TokenStats \| None`. |
-| `get_sessions()`                  | function  | Returns `list[ClaudeSession]` for the current user. Single filesystem pass, non-blocking. Requires Claude Code v2.1.119+.                                                                  |
-| `get_state_counts(sessions=None)` | function  | Returns `dict[ClaudeState, int]` with every `ClaudeState` key present. Pass an existing session list to keep counts consistent with a previously obtained listing; otherwise it re-scans.  |
+<!-- Mirrors the public symbols of src/claude_busy_monitor/_sessions.py — keep in sync -->
+
+```python
+class ClaudeState(Enum):
+    """The state of a live Claude Code session.
+
+    `str(state)` returns the lower-case state name (`"busy"`,
+    `"asking"`, `"idle"`), matching each member's `value`.
+    """
+
+    BUSY = "busy"      # Processing
+    ASKING = "asking"  # Awaiting the user's answer to a menu/dialog (often a permission prompt)
+    IDLE = "idle"      # Awaiting the user's next prompt
+
+
+@dataclass(frozen=True)
+class TokenStats:
+    """Cumulative token usage for one session, summed over its transcript.
+
+    `input` includes fresh prompt tokens plus cache-create and
+    cache-read tokens; counting only `input_tokens` underreports by
+    roughly an order of magnitude on cached prompts.
+    """
+
+    output: int  # sum of assistant.message.usage.output_tokens
+    input: int   # sum of input_tokens + cache_creation + cache_read
+
+
+@dataclass(frozen=True)
+class ClaudeSession:
+    """One live Claude Code session as seen by the running user."""
+
+    path: str                 # absolute project home (cwd of the claude process)
+    name: str                 # last component of `path`
+    id: str                   # session UUID (stem of the active JSONL file); "" if unknown
+    state: ClaudeState
+    stats: TokenStats | None  # None if the transcript is unreadable
+
+
+def get_sessions() -> list[ClaudeSession]:
+    """Return live Claude sessions for the current user, ordered by probe filename.
+
+    Non-blocking: a single filesystem pass over `~/.claude/sessions/`
+    and `~/.claude/projects/`. Requires Claude Code v2.1.119+; sessions
+    from older versions are silently dropped (their probe file lacks
+    the `status` field this tool relies on).
+    """
+
+
+def get_state_counts(
+    sessions: list[ClaudeSession] | None = None,
+) -> dict[ClaudeState, int]:
+    """Count live sessions by state. Every `ClaudeState` key is present.
+
+    Pass `sessions` (typically an earlier `get_sessions()` result) to
+    keep counts consistent with that listing; otherwise this function
+    calls `get_sessions()` itself, which re-scans the filesystem and
+    may reflect a slightly later state.
+    """
+```
 
 ### 1.1. Example
 

--- a/README-LIBRARY.md
+++ b/README-LIBRARY.md
@@ -1,0 +1,89 @@
+# claude-busy-monitor: library and Make reference
+
+Programmer-facing reference for the `claude_busy_monitor` Python library and the project's `make` targets.
+For installation and an overview, see [README.md](README.md).
+
+## 1. Library API
+
+Public names exported from `claude_busy_monitor`:
+
+| Name                              | Kind      | Synopsis                                                                                                                                                                                   |
+| --------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ClaudeState`                     | Enum      | `BUSY`, `ASKING`, `IDLE`. `str(state)` is the lower-case name.                                                                                                                             |
+| `TokenStats`                      | dataclass | Cumulative token totals: `output: int`, `input: int` (input sums fresh, cache-create, cache-read).                                                                                         |
+| `ClaudeSession`                   | dataclass | One live session: `path: str` (cwd of the claude process), `name: str` (basename of `path`), `id: str` (session UUID; `""` if unknown), `state: ClaudeState`, `stats: TokenStats \| None`. |
+| `get_sessions()`                  | function  | Returns `list[ClaudeSession]` for the current user. Single filesystem pass, non-blocking. Requires Claude Code v2.1.119+.                                                                  |
+| `get_state_counts(sessions=None)` | function  | Returns `dict[ClaudeState, int]` with every `ClaudeState` key present. Pass an existing session list to keep counts consistent with a previously obtained listing; otherwise it re-scans.  |
+
+### 1.1. Example
+
+```python
+from claude_busy_monitor import get_sessions, get_state_counts, ClaudeState
+
+# Find sessions stalled on a permission prompt and act on them.
+asking = [s for s in get_sessions() if s.state == ClaudeState.ASKING]
+for s in asking:
+    print(f"waiting: {s.path} ({s.id[:12]})")
+
+# Or just summarise the states.
+counts = get_state_counts()
+print(f"{counts[ClaudeState.BUSY]} busy, {counts[ClaudeState.ASKING]} asking")
+```
+
+Build your own: a tmux notifier, a status-bar widget, a custom dashboard.
+The library exposes the same data the command uses.
+
+## 2. Make targets
+
+Output of `make help`:
+
+```
+Usage: make [TARGET]...
+
+TARGETs:
+
+ General:
+  help               print this help
+
+ Setup:
+  require            install uv (idempotent; Linux)
+  venv-activate      start an interactive shell in updated .venv
+
+ Quality:
+  lint               ruff check + format-check (read-only)
+  format             ruff format + lint autofix (modifies code)
+  check              CI/pre-PR gate: lint unit smoke
+
+ Tests:
+  test-unit          run unit tests (fast, no I/O)
+  test-smoke         run smoke tests (subprocess; no real Claude)
+  test-e2e           run e2e tests (slow; drives real Claude Code)
+  test               fast default tests: unit smoke
+
+ Build and install:
+  build              build wheel + sdist into dist/
+  install            install in user account (CLI on ~/.local/bin/) (1)
+  verify-installed   assert command present and --version matches CHANGES.md
+  uninstall          uninstall from user account (1)
+  verify-uninstalled assert command absent
+  install-legacy     install lib user-wide (1) (2)
+  uninstall-legacy   uninstall lib user-wide (1) (2)
+  cycle              from scratch: uninstall clean lint tests install verify (1)
+
+ Publish to PyPI:
+  publish-quality    pre-publish gate: lint tests reinstall preflight build (1)
+  publish-preflight  pre-flight safety checks for publish (no upload)
+  publish            upload to PyPI (raw; use publish-quality first) (3)
+  publish-tag        tag GitHub project from CHANGES.md version
+
+ Cleanup:
+  clean              remove venv, build artefacts, caches
+
+Notes:
+- All targets activate .venv for themselves.
+- (1) modifies user account.
+- (2) temporary hack for Python code not using venv.
+- (3) prerequisite — store the PyPI token in keyring once
+      (will prompt for the token):
+      keyring set https://upload.pypi.org/legacy/ __token__
+```

--- a/README.md
+++ b/README.md
@@ -4,52 +4,51 @@
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![Status: Stable](https://img.shields.io/badge/status-stable-brightgreen.svg)](CHANGES.md)
 
-Live view of your [Claude Code](https://docs.claude.com/en/docs/claude-code) sessions on your machine — which one is **busy**, which one is **asking** for your input, which one is **idle** — with cumulative token totals.
+Live view of your [Claude Code](https://docs.claude.com/en/docs/claude-code) sessions on your machine: which one is **busy**, which one is **asking** for your input, which one is **idle** (with cumulative token totals).
 
 Ships as a `claude-busy-monitor` command **and** a Python library (`get_sessions()`, `get_state_counts()`).
 
 ![claude-busy-monitor in action](https://raw.githubusercontent.com/pbauermeister/claude-busy-monitor/main/images/hero.svg)
 
-## Why
+## 1. Why
 
 When you run many Claude Code sessions in parallel, keeping an overview of their states is a job in itself.
-You want every session **working** — every minute it isn't is time you don't get back:
+You want every session **working**; every minute it isn't is time you don't get back:
 
-- A **busy** session is the productive one — Claude is doing the work you asked for.
-- An **idle** session is waiting for your next prompt — feed it.
-- An **asking** session is fully stalled on a menu (most often a permission prompt) — answer it to unstuck Claude.
+- A **busy** session is the productive one; Claude is doing the work you asked for.
+- An **idle** session is waiting for your next prompt; feed it.
+- An **asking** session is fully stalled on a menu (most often a permission prompt); answer it to unstuck Claude.
 
 `claude-busy-monitor` surfaces the asking sessions instantly so they don't sit there burning your wall-clock.
 
-## Scope
+## 2. Scope
 
 What it sees and does:
 
-- Local Claude Code sessions of the running user (`~/.claude/sessions/` is per-user — the tool sees only your own sessions).
+- Local Claude Code sessions of the running user.
 - Their live **state** (`busy` / `asking` / `idle`) and cumulative **token totals**.
 
 What it deliberately does **not** do:
 
-- **No API calls** — works entirely from local files; no quota burn, no auth needed.
-- **No web or desktop sessions** — those don't write the `~/.claude/sessions/` files this tool reads.
-- **No mutation, no daemon, no IPC** — read-only, ephemeral, nothing to start or supervise.
+- **No API calls**: works entirely from local files; no quota burn, no auth needed.
+- **No web or desktop sessions**: those don't write the local probe files this tool reads.
+- **No mutation, no daemon, no IPC**: read-only, ephemeral, nothing to start or supervise.
 
-## Features
+## 3. Features
 
 | Feature                      | What it gives you                                                                                                                                        |
 | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **No daemon, no IPC**        | Reads the files Claude Code itself writes. Nothing to start, nothing to keep running.                                                                    |
-| **Authoritative state**      | `status` comes straight from Claude Code's own probe files — no inference, no heuristics, no race-prone proxies.                                         |
+| **Authoritative state**      | `status` comes straight from Claude Code's own probe files; no race-prone proxies.                                                                       |
 | **Cache-aware token totals** | Sums all four `usage` categories (fresh, cache-create, cache-read, output). Naïvely counting only `input_tokens` underreports by ~10× on cached prompts. |
-| **Summary at a glance**      | Coloured pill counts on the first line — scannable from across the room.                                                                                 |
+| **Summary at a glance**      | Coloured pill counts on the first line; scannable from across the room.                                                                                  |
 | **`watch`-friendly**         | Stable, line-oriented output; no spinners, no cursor-move escapes.                                                                                       |
-| **Zero configuration**       | Reads `~/.claude/sessions/` and `~/.claude/projects/`. Nothing to set up.                                                                                |
+| **Zero configuration**       | Nothing to set up; reads only files Claude Code already writes.                                                                                          |
 
-## Install
+## 4. Install
 
 Python 3.11+ is the only prerequisite.
 
-### As a command (most users)
+### 4.1. As a command (most users)
 
 ```bash
 pipx install claude-busy-monitor
@@ -57,11 +56,11 @@ pipx install claude-busy-monitor
 uv tool install claude-busy-monitor
 ```
 
-Both put `claude-busy-monitor` in `~/.local/bin/` inside an isolated per-tool venv — no risk to system Python, clean uninstall. If you have neither: `apt install pipx` (Debian/Ubuntu) or `brew install pipx` (macOS).
+Both put `claude-busy-monitor` in `~/.local/bin/` inside an isolated per-tool venv; no risk to system Python, clean uninstall. If you have neither: `apt install pipx` (Debian/Ubuntu).
 
 Avoid `pip install claude-busy-monitor` system-wide on modern distros (PEP 668 marks system Python as managed; you'd hit `externally-managed-environment` and `--break-system-packages` is a last-resort override, not a recommendation).
 
-### As a library
+### 4.2. As a library
 
 In your project's virtualenv:
 
@@ -71,80 +70,74 @@ pip install claude-busy-monitor
 uv add claude-busy-monitor
 ```
 
-Then `from claude_busy_monitor import get_sessions, get_state_counts, ClaudeState` (full API in [Usage > Library](#library) below).
+Then `from claude_busy_monitor import get_sessions, get_state_counts, ClaudeState` (full API in [README-LIBRARY.md](README-LIBRARY.md)).
 
-### From source (contributors)
+### 4.3. From source (contributors)
 
 ```bash
 git clone https://github.com/pbauermeister/claude-busy-monitor.git
 cd claude-busy-monitor
-make require        # installs uv if missing (idempotent; Linux/macOS)
+make require        # installs uv if missing (idempotent)
 make venv-activate  # creates .venv, syncs dev deps, opens an activated shell
 # or, to install the local source globally for end-to-end use:
 make install        # = uv tool install .
 ```
 
-`make help` lists every target (lint, format, test, build, publish-quality, …).
+For the full list of `make` targets, see [README-LIBRARY.md](README-LIBRARY.md).
 
-## Usage
+## 5. Usage
 
-### Command
+### 5.1. Command
 
 ```bash
-claude-busy-monitor                       # one-shot listing
-watch -n 1 -c claude-busy-monitor         # live refresh (the -c keeps colours)
+claude-busy-monitor               # one-shot listing
+watch claude-busy-monitor         # live refresh
 ```
 
 The output is one summary line followed by one line per session.
 Each session line reads:
 
-| Column | Meaning                                                        |
-| ------ | -------------------------------------------------------------- |
-| 1      | session id (first 12 hex chars)                                |
-| 2      | state pill — `busy` (red) / `asking` (yellow) / `idle` (green) |
-| 3      | working directory (basename)                                   |
-| 4      | output tokens, cumulative (`out:`)                             |
-| 5      | input tokens, cumulative (`in:` — fresh + cached, summed)      |
+| Column | Meaning                                                       |
+| ------ | ------------------------------------------------------------- |
+| 1      | session id (first 12 hex chars)                               |
+| 2      | state pill: `busy` (red) / `asking` (yellow) / `idle` (green) |
+| 3      | working directory (basename)                                  |
+| 4      | output tokens, cumulative (`out:`)                            |
+| 5      | input tokens, cumulative (`in:`, fresh + cached, summed)      |
 
-### Library
+### 5.2. Library
 
-Build your own: a tmux notifier, a status-bar widget, a custom dashboard. The library exposes the same data the command uses.
+The same data is exposed as a Python library; build your own tmux notifier, status-bar widget, or custom dashboard.
 
 ```python
-from claude_busy_monitor import get_sessions, get_state_counts, ClaudeState
+from claude_busy_monitor import get_sessions, ClaudeState
 
-# Find sessions stalled on a permission prompt and act on them.
 asking = [s for s in get_sessions() if s.state == ClaudeState.ASKING]
 for s in asking:
-    print(f"waiting: {s.cwd} ({s.session_id[:12]})")
-
-# Or just summarise the states.
-counts = get_state_counts()
-print(f"{counts[ClaudeState.BUSY]} busy, {counts[ClaudeState.ASKING]} asking")
+    print(f"waiting: {s.path} ({s.id[:12]})")
 ```
 
-Public API: `ClaudeSession`, `ClaudeState`, `TokenStats`, `get_sessions()`, `get_state_counts()`.
+Full API and `make` reference: [README-LIBRARY.md](README-LIBRARY.md).
 
-## How it works
+## 6. How it works
 
 `claude-busy-monitor` reads two on-disk sources that Claude Code itself writes:
 
-1. `~/.claude/sessions/<pid>.json` — one probe file per live session, with the authoritative `status` field (`busy` / `idle` / `waiting`).
-2. `~/.claude/projects/<encoded-cwd>/<sid>.jsonl` — the per-session transcript, used only to total token usage.
+1. `~/.claude/sessions/<pid>.json`: one probe file per live session, with the authoritative `status` field (`busy` / `idle` / `waiting`).
+2. `~/.claude/projects/<encoded-cwd>/<sid>.jsonl`: the per-session transcript, used only to total token usage.
 
-State classification is a one-row table — no inference, no heuristics.
+State classification is a one-row table; no inference, no heuristics.
 Token usage sums the four `usage` categories per assistant entry.
 
-For the full design — assumptions the classifier depends on, diagnostic recipes for when something looks wrong, and the repair playbook — see [README-STATE-DETECTION.md](README-STATE-DETECTION.md).
+For the full design (assumptions the classifier depends on, diagnostic recipes for when something looks wrong, and the repair playbook), see [README-STATE-DETECTION.md](README-STATE-DETECTION.md).
 
-## Compatibility
+## 7. Compatibility
 
-- **Operating system**: Linux (relies on `/proc/<pid>/comm`).
-  macOS is not supported yet — collaboration is very welcome.
-  Please start by [opening a Discussion](https://github.com/pbauermeister/claude-busy-monitor/discussions) so we can align on the approach before any issue or PR.
+- **Operating system**: Linux only (relies on `/proc/<pid>/comm`); macOS is not supported yet.
+  Help welcome: please [open a Discussion](https://github.com/pbauermeister/claude-busy-monitor/discussions) before any issue or PR.
 - **Claude Code**: v2.1.119 introduced the `status` field this tool relies on; older versions are silently dropped.
   `/exit` and `claude --resume <sessionId>` will migrate them.
 
-## License
+## 8. License
 
-[MIT](LICENSE) — see [CHANGES.md](CHANGES.md) for the version history.
+[MIT](LICENSE); see [CHANGES.md](CHANGES.md) for the version history.

--- a/src/claude_busy_monitor/_sessions.py
+++ b/src/claude_busy_monitor/_sessions.py
@@ -31,9 +31,15 @@ PROJECTS_DIR = Path.home() / ".claude" / "projects"
 
 
 class ClaudeState(Enum):
-    BUSY = "busy"
-    ASKING = "asking"  # Awaiting user answer to a menu/dialog
-    IDLE = "idle"  # Awaiting prompt
+    """The state of a live Claude Code session.
+
+    `str(state)` returns the lower-case state name (`"busy"`,
+    `"asking"`, `"idle"`), matching each member's `value`.
+    """
+
+    BUSY = "busy"  # Processing
+    ASKING = "asking"  # Awaiting the user's answer to a menu/dialog (often a permission prompt)
+    IDLE = "idle"  # Awaiting the user's next prompt
 
     def __str__(self) -> str:
         return self.value
@@ -41,7 +47,12 @@ class ClaudeState(Enum):
 
 @dataclass(frozen=True)
 class TokenStats:
-    """Cumulative token usage for a session."""
+    """Cumulative token usage for one session, summed over its transcript.
+
+    `input` includes fresh prompt tokens plus cache-create and
+    cache-read tokens; counting only `input_tokens` underreports by
+    roughly an order of magnitude on cached prompts.
+    """
 
     output: int  # sum of assistant.message.usage.output_tokens
     input: int  # sum of input_tokens + cache_creation + cache_read
@@ -49,11 +60,13 @@ class TokenStats:
 
 @dataclass(frozen=True)
 class ClaudeSession:
+    """One live Claude Code session as seen by the running user."""
+
     path: str  # absolute project home (cwd of the claude process)
-    name: str  # last component of path
-    id: str  # session id (stem of the active JSONL file), "" if unknown
+    name: str  # last component of `path`
+    id: str  # session UUID (stem of the active JSONL file); "" if unknown
     state: ClaudeState
-    stats: TokenStats | None = None  # None if the jsonl is unreadable
+    stats: TokenStats | None = None  # None if the transcript is unreadable
 
 
 # =============================================================================
@@ -201,9 +214,12 @@ def _load_session_probes() -> list[_SessionProbe]:
 
 
 def get_sessions() -> list[ClaudeSession]:
-    """Return live Claude sessions for the current user, with state.
+    """Return live Claude sessions for the current user, ordered by probe filename.
 
-    Non-blocking: single filesystem pass. Requires Claude Code v2.1.119+.
+    Non-blocking: a single filesystem pass over `~/.claude/sessions/`
+    and `~/.claude/projects/`. Requires Claude Code v2.1.119+; sessions
+    from older versions are silently dropped (their probe file lacks
+    the `status` field this tool relies on).
     """
     probes = _load_session_probes()
     if not probes:
@@ -233,13 +249,12 @@ def get_sessions() -> list[ClaudeSession]:
 def get_state_counts(
     sessions: list[ClaudeSession] | None = None,
 ) -> dict[ClaudeState, int]:
-    """Count live sessions by state. All ClaudeState keys are present.
+    """Count live sessions by state. Every `ClaudeState` key is present.
 
-    Pass `sessions` (typically the result of an earlier `get_sessions()`
-    call) to keep the per-state counts consistent with a previously
-    obtained listing — otherwise this function calls `get_sessions()`
-    itself, which re-scans the filesystem and may reflect a slightly
-    later state.
+    Pass `sessions` (typically an earlier `get_sessions()` result) to
+    keep counts consistent with that listing; otherwise this function
+    calls `get_sessions()` itself, which re-scans the filesystem and
+    may reflect a slightly later state.
     """
     counts = {state: 0 for state in ClaudeState}
     sessions_to_count = sessions if sessions is not None else get_sessions()


### PR DESCRIPTION
Closes #15.

## Summary

- New `README-LIBRARY.md`: programmer-facing reference (fenced Python block of public declarations + docstrings, verbatim `make help` output).
- README polish: numbered headings, deduped macOS/sessions-path mentions, em-dashes replaced with `;` / `:` / parentheses, Features table dropped the redundant "No daemon, no IPC" row, Compatibility macOS bullet compressed.
- Bug fix in the README example: `s.cwd` / `s.session_id` → `s.path` / `s.id` (the dataclass exposes `path` and `id`; the prior example would `AttributeError`).
- Library: improved/added docstrings on `ClaudeState`, `TokenStats`, `ClaudeSession`, `get_sessions`, `get_state_counts` (visible via `help()` and IDE hover).
- Makefile `require` target description aligned with Compatibility § 7 ("Linux/macOS only" → "Linux only").
- `CHANGES.md` bumped to v1.0.3.

## Test plan

- [x] `make lint` clean
- [x] `npx prettier --check README.md README-LIBRARY.md` clean
- [x] README and README-LIBRARY.md render correctly on GitHub (verified via GitHub's `/markdown` API: README → 8 h2 / 5 h3 / 2 tables / 5 code blocks; README-LIBRARY → 2 h2 / 1 h3 / 0 tables / 3 code blocks; all relative links resolve; code fences balanced) — final visual check on the rendered PR pending human review
- [x] Library example in README runs against an installed `claude-busy-monitor` (`s.path` and `s.id` resolve on every live session)
- [x] `make help` output in README-LIBRARY.md matches actual `make help` (initial drift on the `require` line caught and fixed in commit `2a68d88`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)