### PR TITLE
[impl] [fast-path] detect sessions with "shell" probe status (v1.0.5)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## Version 1.0.5:
+
+- Detection: recognise the `"shell"` probe `status` (added by Claude Code after v2.1.119) instead of dropping it. Sessions that shelled out (e.g. via `!`, a local bash command, or Ctrl-Z) were silently invisible to the monitor; they now surface as BUSY — to the user the session looks active. `_PROBE_STATUS_MAP` gains a fourth key; README-STATE-DETECTION.md §A4 documents the new value and its idle-refinement derivation.
+
 ## Version 1.0.4:
 
 - CLI: zero-count state badge foreground switched from bright black (`\x1b[90m`) to white (`\x1b[37m`) — bright black was unreadable on terminals whose palette renders it too close to true black.

--- a/README-STATE-DETECTION.md
+++ b/README-STATE-DETECTION.md
@@ -19,12 +19,13 @@ Two on-disk sources, both written by Claude Code itself:
 
 State classification is one table, no inference:
 
-| `probe.status`  | state    | notes                                  |
-| --------------- | -------- | -------------------------------------- |
-| `"busy"`        | `BUSY`   |                                        |
-| `"idle"`        | `IDLE`   |                                        |
-| `"waiting"`     | `ASKING` | `waitingFor` says why; we don't branch |
-| missing / other | dropped  | requires Claude Code v2.1.119+         |
+| `probe.status`  | state    | notes                                            |
+| --------------- | -------- | ------------------------------------------------ |
+| `"busy"`        | `BUSY`   |                                                  |
+| `"idle"`        | `IDLE`   |                                                  |
+| `"shell"`       | `BUSY`   | shelled-out / local bash; idle-refinement (§A4)  |
+| `"waiting"`     | `ASKING` | `waitingFor` says why; we don't branch           |
+| missing / other | dropped  | requires Claude Code v2.1.119+                   |
 
 Sessions from older Claude Code versions (no `status` field) are silently
 dropped. Migrate them by `/exit` + `claude --resume <sessionId>` — the new
@@ -104,8 +105,24 @@ If a future version starts rewriting the sessions file atomically on
 
 ### A4. Live status (Claude Code v2.1.119+)
 
-`status` ∈ `{"busy", "idle", "waiting"}`; `waitingFor` (string, present
-when status is `"waiting"`) carries the waiting reason. Observed values:
+`status` ∈ `{"busy", "shell", "idle", "waiting"}`; `waitingFor` (string,
+present when status is `"waiting"`) carries the waiting reason.
+
+`"shell"` was added after v2.1.119 (observed on v2.1.175). It is an
+_idle refinement_: the binary computes it only when the base status would
+be `"idle"` and a shell sub-mode is active (shelled-out / local-bash
+context — cf. `local_bash:"shell"`, `CLAUDE_BG_SOURCE??"shell"`):
+
+```js
+Y1 = ... ? "waiting" : ... ? "busy" : "idle"; // base status
+XA = Y1 === "idle" && Hf ? "shell" : Y1; // persisted status
+```
+
+We map `"shell" → BUSY` (not IDLE): although Claude is not running an LLM
+turn, the session looks active to the user — something is going on. A
+shelled-out session that we labelled idle would read as "free to use".
+
+`waitingFor` observed values:
 
 - `approve <ToolName>` — permission modal for a specific tool
   (`approve Bash`, `approve Edit`, …). The exact tool name comes from
@@ -115,13 +132,14 @@ when status is `"waiting"`) carries the waiting reason. Observed values:
 - `dialog open` — local slash-command JSX dialog (e.g. `/hooks` UI).
 - `input needed` — generic fallback when none of the above applies.
 
-Used in `_PROBE_STATUS_MAP` (the three-row table) and the
+Used in `_PROBE_STATUS_MAP` (the four-row table) and the
 `isinstance(status, str)` check in `_load_session_probes`.
 
 **Source of truth in the binary:** Claude Code derives the value with
 
 ```js
 let TY = Cw || tA ? "waiting" : j4 || X_ ? "busy" : "idle";
+TY = TY === "idle" && Hf ? "shell" : TY; // shell refinement (post-v2.1.119)
 let If =
   TY !== "waiting"
     ? void 0
@@ -137,20 +155,22 @@ let If =
 gS$({ status: ML, waitingFor: If }); // persisted on every transition
 ```
 
-and validates loaded probes against `vM1 = ["busy","idle","waiting"]`.
+and validates loaded probes against the status array, now
+`t3f = ["busy","shell","idle","waiting"]` (was `vM1 = [...]` pre-shell).
 Both expressions appear in `strings $(which claude)`.
 
 **Symptom** if renamed or removed: every session falls out of the listing
 (state map returns `None` for the new field name).
 
-**Fix:** re-grep the binary for `vM1=` and the `gS$({status` call site,
-then update `_PROBE_STATUS_MAP` (the three values) and the
+**Fix:** re-grep the binary for the status array (`t3f=` / `vM1=`) and the
+`gS$({status` call site, then update `_PROBE_STATUS_MAP` and the
 `data.get("status")` extraction in `_load_session_probes`.
 
-If Claude Code adds a fourth `status` value, decide whether it maps to
-ASKING, BUSY, or a new ClaudeState — _do not_ silently drop it (the loader
-treats unknown statuses as "skip the session", which would make new-state
-sessions vanish from the listing).
+If Claude Code adds a _further_ `status` value, decide whether it maps to
+ASKING, BUSY, IDLE, or a new ClaudeState — _do not_ silently drop it (the
+loader treats unknown statuses as "skip the session", which would make
+new-state sessions vanish from the listing). `"shell"` was the first such
+addition after v2.1.119; it is mapped to BUSY.
 
 ### B. Token usage
 
@@ -214,7 +234,7 @@ jq -c 'del(.message,.snapshot,.content)' \
   ~/.claude/projects/<encoded-cwd>/<sid>.jsonl | tail -20
 
 # 4. What status values does the current claude binary know about?
-strings "$(which claude)" | grep -E '"(busy|idle|waiting)"|vM1=' | head
+strings "$(which claude)" | grep -E '"(busy|shell|idle|waiting)"|t3f=|vM1=' | head
 
 # 5. Where does claude write the status field?
 strings "$(which claude)" | grep -oE '.{40}gS\$\(\{status[^}]+\}' | head

--- a/README.md
+++ b/README.md
@@ -123,10 +123,10 @@ Full API and `make` reference: [README-LIBRARY.md](README-LIBRARY.md).
 
 `claude-busy-monitor` reads two on-disk sources that Claude Code itself writes:
 
-1. `~/.claude/sessions/<pid>.json`: one probe file per live session, with the authoritative `status` field (`busy` / `idle` / `waiting`).
+1. `~/.claude/sessions/<pid>.json`: one probe file per live session, with the authoritative raw `status` field (`busy` / `shell` / `idle` / `waiting`).
 2. `~/.claude/projects/<encoded-cwd>/<sid>.jsonl`: the per-session transcript, used only to total token usage.
 
-State classification is a one-row table; no inference, no heuristics.
+State classification is a fixed lookup that synthesises those raw statuses into the three user-facing states (`busy` / `asking` / `idle`); the mapping is many-to-one — several raw statuses may collapse into one state (e.g. `shell → busy`). No inference, no heuristics.
 Token usage sums the four `usage` categories per assistant entry.
 
 For the full design (assumptions the classifier depends on, diagnostic recipes for when something looks wrong, and the repair playbook), see [README-STATE-DETECTION.md](README-STATE-DETECTION.md).

--- a/architecture/devlog/0021-detect-shell-status.md
+++ b/architecture/devlog/0021-detect-shell-status.md
@@ -39,7 +39,7 @@ Within charter scope.
 
 - Author: agent
 - Model: Claude Opus 4.8
-- Review: pending
+- Review: user
 
 ### 2.1 Steps
 
@@ -57,7 +57,7 @@ Status-map + its docs/tests only. No change to enumeration, transcript reading, 
 
 - Author: agent
 - Model: Claude Opus 4.8
-- Review: pending
+- Review: user
 
 ### 3.1 Implementation deviations
 
@@ -106,11 +106,11 @@ Live install, two real sessions present (`586654.json` busy, `1349668.json` shel
 
 ### 3.8 Retrospective
 
-| #   | Point                                                                                          | Agent | User |
-| --- | ---------------------------------------------------------------------------------------------- | ----- | ---- |
-| 1   | README §A4 had pre-written the exact playbook for "new status value" — diagnosis was fast      | well  |      |
-| 2   | User overruled the IDLE proposal with a clear user-facing rationale (appears active → BUSY)    | well  |      |
-| 3   | `test_version_matches_changes` editable-wheel drift recurred (#17 factoring candidate, hit 2)  | not well |   |
+| #   | Point                                                                                          | Agent    | User       |
+| --- | ---------------------------------------------------------------------------------------------- | -------- | ---------- |
+| 1   | README §A4 had pre-written the exact playbook for "new status value" — diagnosis was fast      | well     | well       |
+| 2   | User overruled the IDLE proposal with a clear user-facing rationale (appears active → BUSY)    | well     | well       |
+| 3   | `test_version_matches_changes` editable-wheel drift recurred (#17 factoring candidate, hit 2)  | not well | ended well |
 
 ### 3.9 Verdict
 

--- a/architecture/devlog/0021-detect-shell-status.md
+++ b/architecture/devlog/0021-detect-shell-status.md
@@ -1,0 +1,154 @@
+# 0021 — Detect sessions with new "shell" probe status
+
+- GH issue: #21
+- Branch: `impl/0021-detect-shell-status`
+- Opened: 2026-06-14
+- Closed: 2026-06-14
+
+## 1. Mandate
+
+- Author: agent
+- Model: Claude Opus 4.8
+- Review: pending
+
+### 1.1 Context
+
+Execution, fast-path. Scope source: user bug report — "claude-busy-monitor detects 1 session but there is another one (pikett-ai-mvp) it misses", later clarified "it was undetected also before I suspended it" (rules out the Ctrl-Z stopped-process state as cause). Accepted on 2026-06-14.
+
+### 1.2 Problem statement
+
+Claude Code (observed v2.1.175) added a fourth probe `status` value, `"shell"` — binary validation array is now `t3f=["busy","shell","idle","waiting"]`. `_PROBE_STATUS_MAP` knew only `busy`/`idle`/`waiting`, so `_load_session_probes` (`_sessions.py:195-197`) treated `"shell"` as unknown and dropped the session. Live repro: `pikett-ai-mvp` (`status:"shell"`) was invisible while running and after Ctrl-Z. Exactly the failure mode README §A4 warned about.
+
+### 1.3 Design decisions
+
+- Map `"shell" → ClaudeState.BUSY` (user decision). The binary derives `"shell"` as an idle refinement (`XA = Y1==="idle" && Hf ? "shell" : Y1`), but to the user a shelled-out session looks active — something is going on — so BUSY, not IDLE. An idle label would read as "free to use".
+- No new `ClaudeState`. A `SHELL` member would ripple into badge colours, the counts API, and tests for no decision-relevant gain (YAGNI).
+
+### 1.4 Acceptance criteria
+
+1. A probe with `status:"shell"` surfaces as a BUSY session (not dropped).
+2. Existing `busy`/`idle`/`waiting` mappings unchanged.
+3. README-STATE-DETECTION.md §A4 + state table document the fourth value.
+4. `make test` green; CHANGES.md v1.0.5 entry written.
+
+### 1.5 Coverage check
+
+Within charter scope.
+
+## 2. Execution plan
+
+- Author: agent
+- Model: Claude Opus 4.8
+- Review: pending
+
+### 2.1 Steps
+
+1. Confirm cause against binary (`strings $(which claude)`) and live probe files.
+2. Add `"shell": ClaudeState.BUSY` to `_PROBE_STATUS_MAP` (`_sessions.py`).
+3. Update README-STATE-DETECTION.md: state table, §A4 (new value + derivation + mapping rationale), source-of-truth array (`vM1`→`t3f`), diagnostic recipe 4.
+4. Update tests: `test_state_map.py` (four keys + shell→BUSY); add `test_probe_parsing_accepts_shell_status_as_busy`.
+5. CHANGES.md v1.0.5; `make format`; `make test` + e2e; live verify; commit; push; PR `Closes #21`.
+
+### 2.2 Scope boundary
+
+Status-map + its docs/tests only. No change to enumeration, transcript reading, token stats, or process-identity checks.
+
+## 3. Closure
+
+- Author: agent
+- Model: Claude Opus 4.8
+- Review: pending
+
+### 3.1 Implementation deviations
+
+None. Plan executed as written.
+
+### 3.2 File inventory
+
+- modified: `src/claude_busy_monitor/_sessions.py` — `"shell": ClaudeState.BUSY` + WHY comment.
+- modified: `README-STATE-DETECTION.md` — state table row; §A4 rewrite; source-of-truth array + shell ternary; recipe 4; repair-playbook wording.
+- modified: `tests/unit/test_state_map.py` — four-key assertion; shell→BUSY test.
+- modified: `tests/unit/test_probe_parsing.py` — `test_probe_parsing_accepts_shell_status_as_busy`.
+- modified: `CHANGES.md` — v1.0.5 entry.
+- new: `architecture/devlog/0021-detect-shell-status.md` — this devlog.
+
+### 3.3 Verification commands
+
+```bash
+strings "$(which claude)" | grep -oE '\["busy","shell","idle","waiting"\]|t3f='   # confirm enum
+make test                                          # 30 unit + 14 smoke green
+uv run pytest tests/e2e                             # 2 passed, 1 skipped
+uv sync --reinstall-package claude-busy-monitor --extra dev   # refresh __version__ → 1.0.5
+uv run python -c "from claude_busy_monitor import get_sessions; \
+  print([(s.name,str(s.state)) for s in get_sessions()])"     # pikett-ai-mvp now BUSY
+```
+
+### 3.4 Coverage check
+
+Within charter scope.
+
+### 3.5 Test review
+
+- _Coverage_: (b) two new tests. `test_state_map_shell_string_maps_to_BUSY_state` + four-key set assertion lock the map; `test_probe_parsing_accepts_shell_status_as_busy` exercises the full loader path. Both fail against pre-change code (which dropped `"shell"`), so they would have caught the original bug.
+- _Effectiveness_: `test_version_matches_changes` bit once during closure (CHANGES.md bump vs stale editable wheel) — resolved with `--reinstall-package`, the known #17 factoring candidate (hit count now 2).
+
+### 3.6 Gate check
+
+- AC #1: ✓ — `test_probe_parsing_accepts_shell_status_as_busy`; live `get_sessions()` shows `pikett-ai-mvp` BUSY.
+- AC #2: ✓ — busy/idle/waiting rows unchanged; existing tests green.
+- AC #3: ✓ — README state table + §A4 updated.
+- AC #4: ✓ — `make test` green (30 unit + 14 smoke); v1.0.5 in CHANGES.md.
+
+### 3.7 Manual validation
+
+Live install, two real sessions present (`586654.json` busy, `1349668.json` shell). Before fix: `get_sessions()` returned only `claude-busy-monitor`. After: both returned, counts `{busy: 2, asking: 0, idle: 0}`.
+
+### 3.8 Retrospective
+
+| #   | Point                                                                                          | Agent | User |
+| --- | ---------------------------------------------------------------------------------------------- | ----- | ---- |
+| 1   | README §A4 had pre-written the exact playbook for "new status value" — diagnosis was fast      | well  |      |
+| 2   | User overruled the IDLE proposal with a clear user-facing rationale (appears active → BUSY)    | well  |      |
+| 3   | `test_version_matches_changes` editable-wheel drift recurred (#17 factoring candidate, hit 2)  | not well |   |
+
+### 3.9 Verdict
+
+**Recommendation**: Accept.
+
+**Rationale**:
+
+- All ACs met; root cause confirmed against the binary and reproduced/fixed on the live install.
+- Two new regression tests fail against pre-change code.
+- `make test` green (30 unit + 14 smoke); e2e green. Single-key map change, no API surface change.
+
+## Governance trace
+
+| Source                                            | Clause                | Action  | Note                                                                    |
+| ------------------------------------------------- | --------------------- | ------- | ----------------------------------------------------------------------- |
+| CEREMONIES.md `Fast-path task flow`               | Eligibility check     | applied | mechanical; mapping decision made by user upfront; scope ≤ paragraph    |
+| README-STATE-DETECTION.md §A4                      | New-status playbook   | applied | "do not silently drop"; decide mapping — followed verbatim              |
+| CLAUDE.md `No task-related commits on main`        | Branch hygiene        | applied | all work on `impl/0021-detect-shell-status`                             |
+| CLAUDE.md `Naming discipline`                      | Outcome-named         | applied | branch / devlog describe WHAT (detect shell status)                     |
+| CLAUDE.md `EN_UK for prose`                        | Spelling              | applied | "recognise", "colour" etc. in prose                                    |
+| CLAUDE.md `YAGNI`                                  | Scope discipline      | applied | no new ClaudeState; status-map only                                     |
+| MEMORY.md `Run make format after every code edit`  | Formatter clean       | applied | `make format` + `ruff format tests` run before commit                  |
+| CEREMONIES.md `Task closure`                       | Task closure ceremony | applied | this section                                                            |
+
+## Resource consumption
+
+| Phase                       | Tokens (approx) | Wall time   |
+| --------------------------- | --------------- | ----------- |
+| Diagnosis (subagent + grep) | ~30k            | 15 min      |
+| Code + docs + tests         | ~20k            | 15 min      |
+| Closure (devlog)            | ~20k            | 15 min      |
+| **Total**                   | **~70k**        | **~45 min** |
+
+| Counter                | Value                                                          |
+| ---------------------- | ------------------------------------------------------------- |
+| Pre-commit hook fails  | 0                                                             |
+| Subagent invocations   | 1 (Explore — detection-logic search)                         |
+| `/clear` events        | 0                                                             |
+| Memory rotation events | 0                                                             |
+| LOC changed            | see `git diff main...HEAD --stat`                            |
+| Files changed          | 6 (`_sessions.py`, README-STATE-DETECTION.md, 2 tests, CHANGES.md, devlog) |
+| Commits on branch      | 1 anticipated (single fast-path commit)                      |

--- a/architecture/devlog/0021-detect-shell-status.md
+++ b/architecture/devlog/0021-detect-shell-status.md
@@ -67,6 +67,7 @@ None. Plan executed as written.
 
 - modified: `src/claude_busy_monitor/_sessions.py` — `"shell": ClaudeState.BUSY` + WHY comment.
 - modified: `README-STATE-DETECTION.md` — state table row; §A4 rewrite; source-of-truth array + shell ternary; recipe 4; repair-playbook wording.
+- modified: `README.md` — §6 corrected: raw `status` set now includes `shell`; "one-row table" → many-to-one synthesis (`shell → busy`). Accuracy fallout from this task's mapping change.
 - modified: `tests/unit/test_state_map.py` — four-key assertion; shell→BUSY test.
 - modified: `tests/unit/test_probe_parsing.py` — `test_probe_parsing_accepts_shell_status_as_busy`.
 - modified: `CHANGES.md` — v1.0.5 entry.
@@ -150,5 +151,5 @@ Live install, two real sessions present (`586654.json` busy, `1349668.json` shel
 | `/clear` events        | 0                                                             |
 | Memory rotation events | 0                                                             |
 | LOC changed            | see `git diff main...HEAD --stat`                            |
-| Files changed          | 6 (`_sessions.py`, README-STATE-DETECTION.md, 2 tests, CHANGES.md, devlog) |
+| Files changed          | 7 (`_sessions.py`, README-STATE-DETECTION.md, README.md, 2 tests, CHANGES.md, devlog) |
 | Commits on branch      | 1 anticipated (single fast-path commit)                      |

--- a/src/claude_busy_monitor/_sessions.py
+++ b/src/claude_busy_monitor/_sessions.py
@@ -79,6 +79,10 @@ class ClaudeSession:
 _PROBE_STATUS_MAP: dict[str, ClaudeState] = {
     "busy": ClaudeState.BUSY,
     "idle": ClaudeState.IDLE,
+    # "shell": Claude is shelled-out / in a local-bash context. The binary
+    # derives it as an idle refinement, but to the user the session looks
+    # active — something is going on — so it counts as BUSY (see README §A4).
+    "shell": ClaudeState.BUSY,
     "waiting": ClaudeState.ASKING,
 }
 

--- a/tests/unit/test_probe_parsing.py
+++ b/tests/unit/test_probe_parsing.py
@@ -73,6 +73,19 @@ def test_probe_parsing_drops_when_pid_is_not_claude(fake_sessions_dir, monkeypat
     assert _load_session_probes() == []
 
 
+def test_probe_parsing_accepts_shell_status_as_busy(fake_sessions_dir, claude_pid_always_valid):
+    # Regression for #21: "shell" probes were dropped, hiding shelled-out
+    # sessions (e.g. pikett-ai-mvp). They must surface as BUSY.
+    _write_probe(
+        fake_sessions_dir,
+        "1.json",
+        {"pid": 123, "cwd": "/home/user/project", "status": "shell"},
+    )
+    probes = _load_session_probes()
+    assert len(probes) == 1
+    assert probes[0].state == ClaudeState.BUSY
+
+
 def test_probe_parsing_accepts_valid_probe(fake_sessions_dir, claude_pid_always_valid):
     _write_probe(
         fake_sessions_dir,

--- a/tests/unit/test_state_map.py
+++ b/tests/unit/test_state_map.py
@@ -1,15 +1,16 @@
-"""Unit tests: `_PROBE_STATUS_MAP` keys exactly match v2.1.119 status enum.
+"""Unit tests: `_PROBE_STATUS_MAP` keys exactly match the claude status enum.
 
-Seed: #3 § 3.7 item 5. Regression target: README §A4 — adding a fourth
+Seed: #3 § 3.7 item 5. Regression target: README §A4 — adding a new
 `status` value without updating the map silently drops affected sessions.
+The `"shell"` key (#21) is the lived instance of that failure mode.
 """
 
 from claude_busy_monitor import ClaudeState
 from claude_busy_monitor._sessions import _PROBE_STATUS_MAP
 
 
-def test_state_map_has_exactly_three_keys():
-    assert set(_PROBE_STATUS_MAP.keys()) == {"busy", "idle", "waiting"}
+def test_state_map_has_exactly_four_keys():
+    assert set(_PROBE_STATUS_MAP.keys()) == {"busy", "shell", "idle", "waiting"}
 
 
 def test_state_map_busy_string_maps_to_BUSY_state():
@@ -18,6 +19,11 @@ def test_state_map_busy_string_maps_to_BUSY_state():
 
 def test_state_map_idle_string_maps_to_IDLE_state():
     assert _PROBE_STATUS_MAP["idle"] == ClaudeState.IDLE
+
+
+def test_state_map_shell_string_maps_to_BUSY_state():
+    # A shelled-out session looks active to the user (#21). README §A4.
+    assert _PROBE_STATUS_MAP["shell"] == ClaudeState.BUSY
 
 
 def test_state_map_waiting_string_maps_to_ASKING_state():


### PR DESCRIPTION
Closes #21

## What

Claude Code (observed v2.1.175) added a fourth probe `status` value, `"shell"` (binary validation array is now `t3f=["busy","shell","idle","waiting"]`). The classifier's `_PROBE_STATUS_MAP` knew only `busy`/`idle`/`waiting`, so `_load_session_probes` dropped any `"shell"` session — making shelled-out sessions (the reported `pikett-ai-mvp`) invisible whether running or Ctrl-Z'd. This is the exact failure mode README §A4 pre-documented for a new status value.

## Decision

Map `"shell" → BUSY`. The binary derives `"shell"` as an idle refinement (`XA = Y1==="idle" && Hf ? "shell" : Y1`), but to the user a shelled-out session looks active — something is going on — so it counts as busy, not idle. No new `ClaudeState` (YAGNI).

## Changes

- `_sessions.py`: `"shell": ClaudeState.BUSY` in `_PROBE_STATUS_MAP`.
- `README-STATE-DETECTION.md`: state table row, §A4 (new value + derivation + mapping rationale), source-of-truth array (`vM1`→`t3f`) + shell ternary, diagnostic recipe 4.
- Tests: four-key map assertion + `shell→BUSY` unit test; `test_probe_parsing_accepts_shell_status_as_busy` (both fail against pre-change code).
- `CHANGES.md`: v1.0.5.
- devlog `0021-detect-shell-status.md`.

## Verification

- `make test` green (30 unit + 14 smoke); `tests/e2e` 2 passed, 1 skipped.
- Live install: before, `get_sessions()` returned only `claude-busy-monitor`; after, both sessions return, counts `{busy: 2, asking: 0, idle: 0}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)